### PR TITLE
fix(CAL-83): fix fzf symlink path and duckdb alias

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ ln -sf ~/sys-config/zsh/functions.shrc ~/.functions.shrc
 ln -sf ~/sys-config/tmux/.tmux.conf ~/.tmux.conf
 ln -sf ~/sys-config/tmux/.tmux ~/.tmux
 ln -sf ~/sys-config/powerline/.p10k.zsh ~/.p10k.zsh
-ln -sf ~/sys-config/fzf/ ~/.fzf
+ln -sf ~/sys-config/fzf/.fzf ~/.fzf
 ln -sf ~/sys-config/git-configs/.gitconfig ~/.gitconfig
 ln -sf ~/sys-config/git-configs/.gitignore_global ~/.gitignore_global
 ln -sf ~/sys-config/nvim/ ~/.config/nvim

--- a/zsh/aliases.shrc
+++ b/zsh/aliases.shrc
@@ -66,7 +66,7 @@ alias R='R --no-restore-data --no-save'
 alias r="radian"
 
 # duckdb
-alias duckdb="/Applications/duckdb ; exit;"
+alias duckdb="/Applications/duckdb"
 
 # terraform
 alias tf="./terraform.sh"


### PR DESCRIPTION
## What changed
- **`setup.sh`**: Fixed fzf symlink target from `~/sys-config/fzf/` to `~/sys-config/fzf/.fzf` — the previous path pointed to the wrapper directory, so `~/.fzf.zsh`, `~/.fzf.bash`, and all custom keybinding scripts were never sourced
- **`zsh/aliases.shrc`**: Removed `; exit;` from `duckdb` alias — this was terminating the shell session whenever duckdb was invoked

## Why
The incorrect fzf symlink was the root cause of all custom fzf keybindings being dead (`ctrl+r` history search, `ctrl+e` editor, `alt+c` cd, `ctrl+o` open). The `~/.fzf.zsh` source in `.zshrc` was sourcing a dead path.

## How to test

### fzf symlink fix
```bash
# 1. Re-run setup to recreate the symlink (or manually recreate it):
ln -sf ~/sys-config/fzf/.fzf ~/.fzf

# 2. Verify the symlink now resolves correctly:
ls ~/.fzf      # should show .fzf.bash, .fzf.zsh, install, uninstall, etc.

# 3. Reload shell:
exec $SHELL

# 4. Test keybindings:
#    ctrl+r  → fzf history search (should open fzf popup)
#    alt+c   → fzf cd (should open fzf directory picker)
```

### duckdb alias fix
```bash
# 1. Source aliases:
source ~/.aliases.shrc

# 2. Launch duckdb:
duckdb

# 3. Verify shell is still alive after exiting duckdb (type .exit or ctrl+d in duckdb)
#    Shell should return to your prompt — NOT exit the terminal
```

## Verification checklist
- [ ] `ls ~/.fzf` shows fzf script files (not empty directory listing)
- [ ] `ctrl+r` opens fzf history popup in a new shell
- [ ] `alt+c` opens fzf directory picker
- [ ] `duckdb` launches without killing the shell session after exit

Closes CAL-83 | CAL-96 | CAL-98