### PR TITLE
fix(CAL-84): remove vi-mode conflict, dead export, add fzf-tab

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -45,6 +45,12 @@ if [ ! -d "$HOME/.oh-my-zsh" ]; then
     echo "Installing Oh My Zsh..."
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 fi
+
+### Install fzf-tab plugin
+if [ ! -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/fzf-tab" ]; then
+    echo "Installing fzf-tab plugin..."
+    git clone https://github.com/Aloxaf/fzf-tab "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/fzf-tab"
+fi
 ### Install fzf shell integration
 echo "Setting up fzf shell integration..."
 $(brew --prefix)/opt/fzf/install --all

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -10,14 +10,17 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 
 # Path to your oh-my-zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
-export ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR=$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting/highlighters
-plugins=(git macos docker docker-compose virtualenv vi-mode poetry)
+plugins=(git macos docker docker-compose virtualenv poetry)
 # installed with brew therefor not in above list: zsh-syntax-highlighting zsh-autosuggestions
 
 #this line should route all .zcompdump files into the cached dir
 export ZSH_COMPDUMP=$ZSH/cache/.zcompdump-$HOST
 
 source $ZSH/oh-my-zsh.sh
+
+# fzf-tab: better tab completion using fzf (must load after compinit, before other plugins that wrap completion)
+[[ -f ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/fzf-tab/fzf-tab.plugin.zsh ]] && \
+  source ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/fzf-tab/fzf-tab.plugin.zsh
 
 # direnv
 eval "$(direnv hook zsh)"


### PR DESCRIPTION
## What changed
- **`zsh/.zshrc`**: Removed `vi-mode` from oh-my-zsh plugins — it intercepts key bindings before fzf can register them, causing `ctrl+r`, `ctrl+t`, and `alt+c` to behave unexpectedly or do nothing
- **`zsh/.zshrc`**: Removed dead `ZSH_HIGHLIGHT_HIGHLIGHTERS_DIR` export — points to `oh-my-zsh/custom/plugins/...` which doesn't exist; `zsh-syntax-highlighting` is brew-installed and auto-discovers its highlighters
- **`zsh/.zshrc`**: Added `fzf-tab` plugin load after `oh-my-zsh.sh` — replaces the default `^I` tab completion with an fzf popup
- **`setup.sh`**: Added fzf-tab clone step so fresh installs get the plugin

## Why
`vi-mode` + fzf is a classic conflict. vi-mode registers keymaps during `oh-my-zsh.sh` source, and fzf tries to override `^R` afterward — but vi-mode's insert/normal mode state machine wins in practice. Removing vi-mode lets fzf own the terminal keybindings cleanly.

## How to test

### vi-mode removal
```bash
# 1. Pull and re-source:
exec $SHELL

# 2. Confirm vi-mode is gone:
bindkey | grep vi     # should show no vi-mode bindings

# 3. Confirm fzf keybindings work:
#    ctrl+r  → fzf history popup
#    ctrl+t  → fzf file picker
#    alt+c   → fzf cd picker
```

### fzf-tab
```bash
# 1. Install plugin if not yet present:
git clone https://github.com/Aloxaf/fzf-tab ~/.oh-my-zsh/custom/plugins/fzf-tab

# 2. Reload shell:
exec $SHELL

# 3. Test tab completion:
cd ~/  # then type: cd <TAB>  → should open fzf popup with directory list
ls /u<TAB>  → fzf popup showing /usr, /usr/bin, etc.
```

### Dead export removal
```bash
# Verify no startup errors related to highlighters:
exec $SHELL 2>&1 | head -20   # no "command not found" or missing file errors
```

## Verification checklist
- [ ] Shell starts cleanly with no errors
- [ ] `ctrl+r` opens fzf history picker (not vi-mode reverse search)
- [ ] Tab completion opens fzf popup instead of cycling completions
- [ ] `bindkey | grep 'vi-mode'` returns empty

Closes CAL-84