### PR TITLE
fix(CAL-85): replace neodev with lazydev, add none-ls executable guards

### DIFF
--- a/nvim/lua/cthayer/plugins/lsp/lspconfig.lua
+++ b/nvim/lua/cthayer/plugins/lsp/lspconfig.lua
@@ -4,7 +4,7 @@ return {
 	dependencies = {
 		"hrsh7th/cmp-nvim-lsp",
 		{ "antosha417/nvim-lsp-file-operations", config = true },
-		{ "folke/neodev.nvim", opts = {} },
+		{ "folke/lazydev.nvim", ft = "lua", opts = {} },
 	},
 	config = function()
 		-- import lspconfig plugin

--- a/nvim/lua/cthayer/plugins/none-ls.lua
+++ b/nvim/lua/cthayer/plugins/none-ls.lua
@@ -2,14 +2,24 @@ return {
 	"nvimtools/none-ls.nvim",
 	config = function()
 		local null_ls = require("null-ls")
+
+		local function cond(bin)
+			return function()
+				return vim.fn.executable(bin) == 1
+			end
+		end
+
 		null_ls.setup({
 			sources = {
-				null_ls.builtins.formatting.stylua,
-				null_ls.builtins.formatting.prettier,
-				null_ls.builtins.formatting.black,
-				null_ls.builtins.formatting.isort,
+				null_ls.builtins.formatting.stylua.with({ condition = cond("stylua") }),
+				null_ls.builtins.formatting.prettier.with({ condition = cond("prettier") }),
+				null_ls.builtins.formatting.black.with({ condition = cond("black") }),
+				null_ls.builtins.formatting.isort.with({ condition = cond("isort") }),
 				null_ls.builtins.completion.spell,
-				null_ls.builtins.diagnostics.pylint.with({ extra_args = { "--rcfile=/Users/cthayer/.pylintrc" } }),
+				null_ls.builtins.diagnostics.pylint.with({
+					extra_args = { "--rcfile=" .. vim.fn.expand("~/.pylintrc") },
+					condition = cond("pylint"),
+				}),
 			},
 		})
 		vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})


### PR DESCRIPTION
## What changed
- **`nvim/lua/cthayer/plugins/lsp/lspconfig.lua`**: Replaced `folke/neodev.nvim` with `folke/lazydev.nvim` — neodev is archived and no longer maintained; lazydev is the successor with better Neovim 0.11+ API support and only loads for `ft = "lua"` files
- **`nvim/lua/cthayer/plugins/none-ls.lua`**: Added `vim.fn.executable()` guards to all sources — previously Neovim would throw errors at startup if `stylua`, `prettier`, `black`, `isort`, or `pylint` weren't installed
- **`nvim/lua/cthayer/plugins/none-ls.lua`**: Fixed hardcoded `/Users/cthayer/.pylintrc` path — replaced with `vim.fn.expand("~/.pylintrc")` so the config is portable

## Why
`neodev.nvim` is archived (read-only) and won't receive updates for Neovim 0.11+ API changes. `lazydev.nvim` is the maintained drop-in with the same lua-ls type injection capability. The none-ls guards prevent the "attempt to call nil" errors when formatters aren't present on a fresh install.

## How to test

### lazydev
```
# 1. Open nvim
nvim

# 2. Open a lua file:
:e ~/.config/nvim/lua/cthayer/plugins/lsp/lspconfig.lua

# 3. Verify lua_ls completions still work — type vim. and confirm autocomplete suggestions appear
# 4. Run :checkhealth lazy — should show lazydev loaded, no neodev warnings
```

### none-ls guards
```
# 1. Temporarily rename a binary to simulate missing tool:
which stylua     # note path
mv $(which stylua) /tmp/stylua_bak

# 2. Restart nvim — should load cleanly with no errors

# 3. Restore:
mv /tmp/stylua_bak $(which stylua)
```

### Portable path
```
# 1. In nvim, check that pylint config expands correctly:
:lua print(vim.fn.expand("~/.pylintrc"))
# Should print your actual home path, e.g. /Users/caseythayer/.pylintrc
```

## Verification checklist
- [ ] `:checkhealth` shows no errors for lazydev
- [ ] Lua autocomplete works in `.lua` files (vim.* completions)
- [ ] Neovim starts cleanly even with missing formatters
- [ ] No hardcoded username path in none-ls config

Closes CAL-85 | CAL-102 | CAL-104