### PR TITLE
fix(CAL-87): update git identity to caseyluna

### DIFF
--- a/git-configs/.gitconfig
+++ b/git-configs/.gitconfig
@@ -1,5 +1,5 @@
 [user]
-	name = thayerca
+	name = caseyluna
 	email = casey.thayer6@gmail.com
 [init]
 	defaultBranch = main
@@ -9,7 +9,7 @@
   eol = lf
 	pager = delta
 [github]
-	user = thayerca
+	user = caseyluna
 [diff]
   tool = nvimdiff #meld
   colorMoved = default


### PR DESCRIPTION
## What changed
- **`git-configs/.gitconfig`**: Updated `[user] name` from `thayerca` to `caseyluna`
- **`git-configs/.gitconfig`**: Updated `[github] user` from `thayerca` to `caseyluna`

## Why
GitHub account was renamed to `caseyluna`. The old `thayerca` identity was causing commits to show the wrong author name and `gh` CLI integrations to fail auth checks.

## How to test
```bash
# 1. Pull branch and verify symlink is in place:
ln -sf ~/sys-config/git-configs/.gitconfig ~/.gitconfig

# 2. Check git identity:
git config --global user.name     # should print: caseyluna
git config --global github.user   # should print: caseyluna

# 3. Make a test commit in any repo and verify author in log:
git log -1 --format="%an"         # should print: caseyluna
```

## Verification checklist
- [ ] `git config --global user.name` returns `caseyluna`
- [ ] `git config --global github.user` returns `caseyluna`
- [ ] New commits show `caseyluna` as author

Closes CAL-87