### PR TITLE
fix(CAL-90): fix tmux plugin order, remove duplicates, add tmux-sensible

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -3,7 +3,7 @@ set-option -g default-shell /bin/zsh
 
 # Enable true color support
 set -g default-terminal "tmux-256color"
-#set -ga terminal-overrides ",xterm-256color:Tc"
+set -ga terminal-overrides ",xterm-256color:Tc"
 
 # When closing a session, go to the next one
 set-option -g detach-on-destroy off
@@ -15,45 +15,6 @@ set -g mouse on
 unbind C-b
 set-option -g prefix C-a
 set-option -g repeat-time 0
-
-# Catppuccin Theme for Tmux
-set -g @plugin 'catppuccin/tmux#v2.1.0'
-
-# Configure the catppuccin plugin
-set -g @catppuccin_flavor "mocha"
-set -g @catppuccin_window_status_style "rounded"
-#set -g @catppuccin_status_background "#242638" 
-set -g @catppuccin_window_current_text " #{b:pane_current_path}"
-set -g @catppuccin_window_text " #{b:pane_current_path}"
-
-# Load catppuccin
-set -g @plugin 'tmux-plugins/tmux-battery'
-
-# Make the status line pretty and add some modules
-set -g status-right-length 100
-set -g status-left-length 100
-set -g status-left ""
-set -g status-right "#{E:@catppuccin_status_application}"
-set -agF status-right "#{E:@catppuccin_status_battery}"
-set-window-option -g status-position bottom 
-
-run -b "~/.tmux/plugins/tpm/tpm"
-
-# Tmux Plugin Manager (TPM) and plugins
-# TPM: Plugin manager for Tmux
-set -g @plugin 'tmux-plugins/tpm'
-
-# tmux-yank: Enables copying text to system clipboard
-set -g @plugin 'tmux-plugins/tmux-yank'
-
-# tmux-fzf: Integrates fzf for fuzzy finding sessions and windows
-set -g @plugin 'sainnhe/tmux-fzf'
-
-# vim-tmux-navigator: Seamless navigation between tmux panes and vim splits
-set -g @plugin 'christoomey/vim-tmux-navigator'
-
-# catppuccin/tmux: Aesthetic theme for Tmux
-set -g @plugin 'catppuccin/tmux'
 
 # Copy mode settings
 bind 'v' copy-mode
@@ -74,6 +35,42 @@ bind - split-window -v
 # Reload Tmux configuration
 unbind r
 bind r source-file ~/.tmux.conf \; display 'Reloaded!'
+
+# ── Plugins ────────────────────────────────────────────────────────────────────
+# TPM: Plugin manager — must be first
+set -g @plugin 'tmux-plugins/tpm'
+
+# tmux-sensible: Sane defaults everyone agrees on
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+# tmux-yank: Copy text to system clipboard
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+# tmux-battery: Battery status in status bar
+set -g @plugin 'tmux-plugins/tmux-battery'
+
+# tmux-fzf: Fuzzy find sessions and windows
+set -g @plugin 'sainnhe/tmux-fzf'
+
+# vim-tmux-navigator: Seamless navigation between tmux panes and vim splits
+set -g @plugin 'christoomey/vim-tmux-navigator'
+
+# Catppuccin theme
+set -g @plugin 'catppuccin/tmux#v2.1.0'
+
+# ── Catppuccin config ──────────────────────────────────────────────────────────
+set -g @catppuccin_flavor "mocha"
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_window_current_text " #{b:pane_current_path}"
+set -g @catppuccin_window_text " #{b:pane_current_path}"
+
+# Status bar
+set -g status-right-length 100
+set -g status-left-length 100
+set -g status-left ""
+set -g status-right "#{E:@catppuccin_status_application}"
+set -agF status-right "#{E:@catppuccin_status_battery}"
+set-window-option -g status-position bottom
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## What changed
- **`tmux/.tmux.conf`**: Removed duplicate `catppuccin/tmux` plugin declaration — it was declared once as `catppuccin/tmux#v2.1.0` (line 20) and again as `catppuccin/tmux` (line 56)
- **`tmux/.tmux.conf`**: Removed duplicate `run '~/.tmux/plugins/tpm/tpm'` — was being run at line 40 (before half the plugins were declared!) AND at line 79. Plugins declared after the first `run` were never being initialized by TPM
- **`tmux/.tmux.conf`**: Reorganized: all plugin declarations now come together before the single `run tpm` at the bottom
- **`tmux/.tmux.conf`**: Added `tmux-plugins/tmux-sensible` — provides sane tmux defaults (escape time, scrollback, etc.)
- **`tmux/.tmux.conf`**: Uncommented `terminal-overrides` line for proper true color in terminals that support it

## Why
TPM requires all `@plugin` declarations to appear before `run tpm`. Having `run tpm` in the middle meant `tmux-yank`, `tmux-fzf`, `vim-tmux-navigator`, and the second catppuccin declaration were all being ignored — TPM never saw them.

## How to test
```bash
# 1. Reload tmux config:
tmux source-file ~/.tmux.conf

# 2. Install all plugins via TPM:
#    In tmux: prefix + I   (capital i)
#    Should show all plugins downloading/updating

# 3. Verify plugins loaded:
#    - Battery % should appear in status bar (tmux-battery)
#    - Copy with 'y' in copy-mode should hit system clipboard (tmux-yank)
#    - ctrl+h/j/k/l should navigate between nvim splits and tmux panes (vim-tmux-navigator)

# 4. Verify no duplicate plugin errors in tmux:
tmux source-file ~/.tmux.conf   # should show "Reloaded!" with no errors
```

## Verification checklist
- [ ] `prefix + I` installs plugins without errors
- [ ] Battery status shows in tmux status bar
- [ ] `y` in copy-mode copies to system clipboard
- [ ] `ctrl+h/l` navigates between vim and tmux panes
- [ ] No "duplicate plugin" warnings

Closes CAL-90