### PR TITLE
feat(CAL-91): expand ghostty config with font, padding, shell integration

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1,1 +1,20 @@
 theme = catppuccin-mocha
+
+# Font
+font-family = JetBrainsMono Nerd Font
+font-size = 13
+
+# Window
+window-padding-x = 8
+window-padding-y = 8
+
+# Scrollback
+scrollback-limit = 10000
+
+# Cursor
+cursor-style = bar
+cursor-style-blink = true
+
+# Shell integration (enables OSC sequences for better tmux/nvim interop)
+shell-integration = zsh
+shell-integration-features = cursor,sudo,title


### PR DESCRIPTION
## What changed
**`ghostty/config`** expanded from a single `theme` line to a full config:
- **Font**: JetBrainsMono Nerd Font, size 13
- **Padding**: 8px on all sides for visual breathing room
- **Scrollback**: 10,000 lines (up from default ~1000)
- **Cursor**: bar style with blink (clearer than block in insert mode)
- **Shell integration**: zsh integration enabled with cursor/sudo/title features

## Why
The Ghostty config was essentially empty — just a theme. Without font configuration, Ghostty falls back to system monospace which may not have Nerd Font glyphs (breaking nvim icons, tmux symbols, powerline). Shell integration enables OSC sequences for nvim cursor shape changes inside Ghostty, proper window titles, and sudo prompt detection.

## How to test
```bash
# 1. Verify ghostty config symlink:
ls -la ~/.config/ghostty/config   # should point to ~/sys-config/ghostty/config

# 2. Restart Ghostty

# 3. Verify:
#    - Font: JetBrainsMono Nerd Font renders (check: ls command shows icons via eza)
#    - Padding: visible margin around terminal content
#    - Cursor: blinking bar (not block)
#    - Scrollback: scroll up > 1000 lines in a long output to verify

# 4. Test nvim cursor shape passthrough:
#    Open nvim → enter insert mode → cursor should change to bar
#    Exit insert mode → cursor should return to block
```

## Verification checklist
- [ ] Ghostty launches without config errors
- [ ] JetBrainsMono Nerd Font renders correctly (icons in `ls`/eza visible)
- [ ] Window padding is visible around terminal content
- [ ] Cursor displays as blinking bar
- [ ] Nvim cursor shape changes on mode switch

Closes CAL-91