### PR TITLE
feat(CAL-108): replace alpha dashboard with useful quick-action layout

### DIFF
--- a/nvim/lua/cthayer/plugins/alpha.lua
+++ b/nvim/lua/cthayer/plugins/alpha.lua
@@ -3,18 +3,79 @@ return {
 	event = "VimEnter",
 	config = function()
 		local alpha = require("alpha")
-		local dashboard = require("alpha.themes.startify")
+		local dashboard = require("alpha.themes.dashboard")
 
-		-- Set header
-		dashboard.section.header.val = {
-			"                                                     ",
-			"  ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗ ",
-			"  ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║ ",
-			"  ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║ ",
-			"  ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║ ",
-			"  ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║ ",
-			"  ╚═╝  ╚═══╝╚══════╝ ╚═════╝   ╚═══╝  ╚═╝╚═╝     ╚═╝ ",
-			"                                                     ",
+		-- ── Header ──────────────────────────────────────────────────────────────
+		local function greeting()
+			local hour = tonumber(os.date("%H"))
+			local greet
+			if hour < 5 then
+				greet = "  Still up?"
+			elseif hour < 12 then
+				greet = "  Good morning"
+			elseif hour < 17 then
+				greet = "  Good afternoon"
+			elseif hour < 21 then
+				greet = "  Good evening"
+			else
+				greet = "  Good night"
+			end
+			return greet
+		end
+
+		local function header()
+			local date = os.date("  %A, %B %d")
+			local cwd = vim.fn.fnamemodify(vim.fn.getcwd(), ":~")
+			return {
+				"",
+				greeting(),
+				date,
+				"  " .. cwd,
+				"",
+			}
+		end
+
+		dashboard.section.header.val = header()
+		dashboard.section.header.opts = {
+			hl = "AlphaHeader",
+			position = "center",
+		}
+
+		-- ── Buttons ──────────────────────────────────────────────────────────────
+		dashboard.section.buttons.val = {
+			dashboard.button("n", "  New file", "<cmd>ene <BAR> startinsert<CR>"),
+			dashboard.button("e", "  Explorer", "<cmd>Neotree toggle<CR>"),
+			dashboard.button("f", "  Find file", "<cmd>Telescope find_files<CR>"),
+			dashboard.button("F", "  Git files", "<cmd>Telescope git_files<CR>"),
+			dashboard.button("w", "  Find word", "<cmd>Telescope live_grep<CR>"),
+			dashboard.button("r", "  Recent files", "<cmd>Telescope oldfiles<CR>"),
+			dashboard.button("b", "  Git branches", "<cmd>Telescope git_branches<CR>"),
+			dashboard.button("g", "  Git status", "<cmd>LazyGit<CR>"),
+			dashboard.button("t", "  Find todos", "<cmd>TodoTelescope<CR>"),
+			dashboard.button("p", "  Plugins", "<cmd>Lazy<CR>"),
+			dashboard.button("c", "  Config", "<cmd>e $MYVIMRC<CR>"),
+			dashboard.button("l", "  Changelog", "<cmd>LazyChangelog<CR>"),
+			dashboard.button("q", "  Quit", "<cmd>qa<CR>"),
+		}
+
+		-- ── Footer ──────────────────────────────────────────────────────────────
+		local function footer()
+			local ok, lazy = pcall(require, "lazy")
+			if not ok then
+				return ""
+			end
+			local stats = lazy.stats()
+			local updates = ""
+			if stats.updates and stats.updates > 0 then
+				updates = "  " .. stats.updates .. " update" .. (stats.updates > 1 and "s" or "") .. " available"
+			end
+			return "⚡ " .. stats.loaded .. "/" .. stats.count .. " plugins loaded" .. updates
+		end
+
+		dashboard.section.footer.val = footer()
+		dashboard.section.footer.opts = {
+			hl = "AlphaFooter",
+			position = "center",
 		}
 
 		alpha.setup(dashboard.opts)


### PR DESCRIPTION
## What changed
**`nvim/lua/cthayer/plugins/alpha.lua`** — complete overhaul of the startup dashboard:

- **Header**: Dynamic greeting based on time of day, current date, and current working directory
- **13 action buttons** with single-key shortcuts:
  | Key | Action |
  |-----|--------|
  | `n` | New file |
  | `e` | Neo-tree file explorer |
  | `f` | Telescope find files |
  | `F` | Telescope git files (tracked only) |
  | `w` | Telescope live grep (find word) |
  | `r` | Recent files (oldfiles) |
  | `b` | Git branches picker |
  | `g` | LazyGit |
  | `t` | TodoTelescope |
  | `p` | Lazy plugin manager |
  | `c` | Open `$MYVIMRC` |
  | `l` | Lazy changelog |
  | `q` | Quit |
- **Footer**: Shows `X/Y plugins loaded` + pending update count from lazy.nvim stats

## How to test
```
# 1. Open nvim without a file argument:
nvim

# 2. Verify dashboard renders:
#    - Header shows greeting + date + cwd
#    - All 13 buttons listed
#    - Footer shows plugin count

# 3. Test each button:
#    Press 'f' → Telescope find_files should open
#    Press 'F' → Telescope git_files should open (must be in a git repo)
#    Press 'b' → Branch picker should open
#    Press 'g' → LazyGit should open
#    Press 'q' → nvim should quit

# 4. Test from a different directory:
cd /tmp && nvim
#    Header cwd should show /tmp
```

## Verification checklist
- [ ] Dashboard renders on `nvim` (no file arg)
- [ ] Greeting changes based on time of day
- [ ] Date and cwd are correct in header
- [ ] All 13 buttons are visible and functional
- [ ] Footer shows plugin load count
- [ ] `F` opens git files picker (different from `f`)
- [ ] `b` opens branch picker

Closes CAL-108