### PR TITLE
feat(CAL-95): add lint.sh and GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint configs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Homebrew dependencies
+        run: |
+          brew install zsh luajit tmux
+
+      - name: Run lint
+        run: bash scripts/lint.sh

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# lint.sh — validate config files for syntax errors
+# Run locally: bash scripts/lint.sh
+# Run in CI: automatically via .github/workflows/lint.yml
+
+set -euo pipefail
+
+ERRORS=0
+
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; ERRORS=$((ERRORS + 1)); }
+section() { echo ""; echo "── $1 ──"; }
+
+# ── Zsh syntax ──────────────────────────────────────────────────────────────
+section "Zsh syntax"
+if command -v zsh &>/dev/null; then
+  for f in zsh/.zshrc zsh/.zprofile zsh/aliases.shrc zsh/functions.shrc; do
+    if [ -f "$f" ]; then
+      if zsh -n "$f" 2>/dev/null; then
+        pass "$f"
+      else
+        fail "$f — zsh syntax error"
+      fi
+    fi
+  done
+else
+  echo "  (skipped — zsh not available)"
+fi
+
+# ── Bash syntax ──────────────────────────────────────────────────────────────
+section "Bash syntax"
+for f in setup.sh scripts/*.sh; do
+  if [ -f "$f" ]; then
+    if bash -n "$f" 2>/dev/null; then
+      pass "$f"
+    else
+      fail "$f — bash syntax error"
+    fi
+  fi
+done
+
+# ── Lua syntax (Neovim config) ───────────────────────────────────────────────
+section "Lua syntax"
+if command -v luac &>/dev/null; then
+  while IFS= read -r -d '' f; do
+    if luac -p "$f" 2>/dev/null; then
+      pass "$f"
+    else
+      fail "$f — lua syntax error"
+    fi
+  done < <(find nvim/lua -name "*.lua" -print0 2>/dev/null)
+elif command -v nvim &>/dev/null; then
+  # Fallback: use nvim --headless to check lua
+  while IFS= read -r -d '' f; do
+    if nvim --headless -c "luafile $f" -c "qa!" 2>/dev/null; then
+      pass "$f"
+    else
+      fail "$f — lua/nvim load error"
+    fi
+  done < <(find nvim/lua -name "*.lua" -print0 2>/dev/null)
+else
+  echo "  (skipped — luac and nvim not available)"
+fi
+
+# ── Tmux config ──────────────────────────────────────────────────────────────
+section "Tmux config"
+if command -v tmux &>/dev/null; then
+  if tmux -f tmux/.tmux.conf new-session -d -s lint_check 2>/dev/null; then
+    tmux kill-session -t lint_check 2>/dev/null || true
+    pass "tmux/.tmux.conf"
+  else
+    fail "tmux/.tmux.conf — tmux config error"
+  fi
+else
+  echo "  (skipped — tmux not available)"
+fi
+
+# ── Result ────────────────────────────────────────────────────────────────────
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+  echo "All checks passed."
+  exit 0
+else
+  echo "$ERRORS error(s) found."
+  exit 1
+fi


### PR DESCRIPTION
## What changed
- **`scripts/lint.sh`**: New script that validates:
  - Zsh syntax for all `.zshrc`, `.zprofile`, `aliases.shrc`, `functions.shrc`
  - Bash syntax for `setup.sh` and all scripts
  - Lua syntax for all `nvim/lua/**/*.lua` files (via `luac` or `nvim --headless`)
  - Tmux config parse via `tmux -f tmux/.tmux.conf new-session`
  - Reports pass/fail per file, exits 1 on any error
- **`.github/workflows/lint.yml`**: Runs `lint.sh` on every push and PR to `main` using `macos-latest`

## Why
Without CI, a syntax error in `.zshrc`, a bad lua config, or a broken tmux.conf can be committed and silently break your shell or editor on the next pull. The CI catches these before merge.

## How to test
```bash
# Run locally from sys-config root:
bash scripts/lint.sh

# Expected output on clean repo:
# ── Zsh syntax ──
#   ✓ zsh/.zshrc
#   ✓ zsh/aliases.shrc
#   ...
# ── Bash syntax ──
#   ✓ setup.sh
#   ...
# All checks passed.

# Test failure detection:
echo "invalid zsh {{{{" >> zsh/aliases.shrc
bash scripts/lint.sh    # should exit 1 with error
git checkout zsh/aliases.shrc  # restore
```

## Verification checklist
- [ ] `bash scripts/lint.sh` exits 0 on the current clean repo
- [ ] Introducing a syntax error causes `lint.sh` to exit 1
- [ ] GitHub Actions workflow appears in the repo's Actions tab after merge
- [ ] CI passes on this PR

Closes CAL-95