### PR TITLE
fix(CAL-85): replace neodev→lazydev, none-ls guards, mason dedup

### DIFF
--- a/nvim/lua/cthayer/plugins/lspconfig.lua
+++ b/nvim/lua/cthayer/plugins/lspconfig.lua
@@ -13,7 +13,7 @@ return {
 	dependencies = {
 		"hrsh7th/cmp-nvim-lsp",
 		{ "antosha417/nvim-lsp-file-operations", config = true },
-		{ "folke/neodev.nvim", opts = {} },
+		{ "folke/lazydev.nvim", ft = "lua", opts = {} },
 	},
 	config = function()
 		local cmp_nvim_lsp = require("cmp_nvim_lsp")

--- a/nvim/lua/cthayer/plugins/mason.lua
+++ b/nvim/lua/cthayer/plugins/mason.lua
@@ -43,7 +43,6 @@ return {
 			ensure_installed = {
 				"ruff", -- Formatter + linter
 				"stylua", -- Lua formatter
-				"bash-language-server",
 				"prettier",
 			},
 		})

--- a/nvim/lua/cthayer/plugins/none-ls.lua
+++ b/nvim/lua/cthayer/plugins/none-ls.lua
@@ -44,10 +44,10 @@ return {
 				},
 
 				-- 🔍 Linters
-				--TODO: fix these built-ins executables are not being found
-				--diagnostics.ruff, -- Python (linter)
-				--diagnostics.eslint_d, -- JS/TS
-				--diagnostics.shellcheck, -- Shell
+				-- guarded: only register if binary is installed
+				vim.fn.executable("ruff") == 1 and diagnostics.ruff or nil, -- Python
+				vim.fn.executable("eslint_d") == 1 and diagnostics.eslint_d or nil, -- JS/TS
+				vim.fn.executable("shellcheck") == 1 and diagnostics.shellcheck or nil, -- Shell
 				diagnostics.stylelint, -- CSS/SCSS
 				diagnostics.yamllint, -- YAML
 				diagnostics.markdownlint, -- Markdown


### PR DESCRIPTION
## What changed
- **`lspconfig.lua`**: Replaced archived `folke/neodev.nvim` with `folke/lazydev.nvim` (ft=lua) — neodev is read-only/abandoned; lazydev is the maintained successor
- **`none-ls.lua`**: Added `vim.fn.executable()` guards to `ruff`, `eslint_d`, `shellcheck` so they only register when the binary is installed (fixes the TODO comment that's been there forever)
- **`mason.lua`**: Removed `"bash-language-server"` from `mason_tool_installer.ensure_installed` — duplicates `"bashls"` in `mason_lspconfig.ensure_installed`, causing Mason to install it twice

## How to test
\`\`\`
# lazydev
nvim some_file.lua
# type vim. and verify autocomplete suggestions appear
:checkhealth lazy   # should show lazydev, no neodev warnings

# none-ls guards — test without shellcheck installed:
which shellcheck && mv $(which shellcheck) /tmp/sc_bak
nvim  # should start cleanly, no errors
mv /tmp/sc_bak $(which shellcheck)
\`\`\`

## Verification checklist
- [ ] No neodev warnings in `:checkhealth`
- [ ] Lua autocomplete works in `.lua` files
- [ ] Nvim starts cleanly when a guarded linter isn't installed
- [ ] Mason doesn't install bash-language-server twice

Closes CAL-85 | CAL-101 | CAL-102 | CAL-103 | CAL-104