### PR TITLE
fix(CAL-88): fix nvimdiff mergetool — invalid -ancestor/-merge flags

### DIFF
--- a/git-configs/.gitconfig
+++ b/git-configs/.gitconfig
@@ -58,7 +58,7 @@
   conflictstyle = diff3
 
 [mergetool "nvimdiff"]
-  cmd = nvim -d "$LOCAL" "$REMOTE" -ancestor "$BASE" -merge "$MERGED"
+  cmd = nvim -d "$LOCAL" "$MERGED" "$REMOTE" -c '$wincmd w' -c 'wincmd J'
   trustExitCode = true
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## What changed
**`git-configs/.gitconfig`** — Fixed `[mergetool "nvimdiff"]` command

**Before** (broken — unknown nvim flags):
\`\`\`
cmd = nvim -d "$LOCAL" "$REMOTE" -ancestor "$BASE" -merge "$MERGED"
\`\`\`

**After** (working 3-pane merge):
\`\`\`
cmd = nvim -d "$LOCAL" "$MERGED" "$REMOTE" -c '$wincmd w' -c 'wincmd J'
\`\`\`

## How to test
\`\`\`bash
# Create a merge conflict in any repo, then:
git mergetool --tool=nvimdiff
# nvim should open with 3 panes (LOCAL | MERGED | REMOTE)
# NOT fail with "unknown flag" error
\`\`\`

## Verification checklist
- [ ] `git mergetool --tool=nvimdiff` opens nvim (no error)
- [ ] 3 panes visible: LOCAL, MERGED, REMOTE

Closes CAL-88