### PR TITLE
fix(CAL-90): declare tmux-battery and tmux-sensible plugins

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -75,6 +75,12 @@ unbind -T copy-mode-vi MouseDragEnd1Pane
 # ------------------------------------------------------------------------------
 set -g @plugin 'tmux-plugins/tpm'
 
+# tmux-sensible: sane defaults everyone agrees on (escape time, scrollback, etc.)
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+# tmux-battery: battery status for status bar (used in @catppuccin_status_battery)
+set -g @plugin 'tmux-plugins/tmux-battery'
+
 # tmux-yank: copy selection to system clipboard (OSC52 or external tool)
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @yank_selection 'clipboard'


### PR DESCRIPTION
## What changed
- **`tmux/.tmux.conf`**: Added `tmux-plugins/tmux-battery` — used in status-right via `#{E:@catppuccin_status_battery}` but was never declared, so `prefix+I` on a fresh install would leave the status bar broken
- **`tmux/.tmux.conf`**: Added `tmux-plugins/tmux-sensible` — sane baseline defaults (escape time, scrollback, etc.)

## How to test
\`\`\`bash
tmux source-file ~/.tmux.conf
# In tmux: prefix + I   (install plugins)
# Battery % should appear in status bar after install
\`\`\`

## Verification checklist
- [ ] `prefix+I` installs without errors
- [ ] Battery status appears in tmux status bar

Closes CAL-90