### PR TITLE
feat(CAL-91): expand ghostty config with font, padding, shell integration

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1,5 +1,24 @@
 theme = catppuccin-mocha
 
+# Font
+font-family = JetBrainsMono Nerd Font
+font-size = 13
+
+# Window
+window-padding-x = 8
+window-padding-y = 8
+
+# Scrollback
+scrollback-limit = 10000
+
+# Cursor
+cursor-style = bar
+cursor-style-blink = true
+
+# Shell integration (OSC sequences: nvim cursor shape, window titles, sudo prompts)
+shell-integration = zsh
+shell-integration-features = cursor,sudo,title
+
 # Splits: split right (main | new), split down (top | bottom). Navigate with super+arrows.
 keybind = super+d = new_split:right
 keybind = super+shift+d = new_split:down


### PR DESCRIPTION
## What changed
**`ghostty/config`** — expanded from theme + keybinds only:
- Font: JetBrainsMono Nerd Font, size 13 (Nerd Font glyphs for nvim/tmux icons)
- Window padding: 8px x/y
- Scrollback: 10,000 lines
- Cursor: blinking bar style
- Shell integration: zsh with cursor/sudo/title features

## How to test
\`\`\`bash
# Restart Ghostty
# Verify: JetBrainsMono renders, icons visible in eza/nvim
# Verify: blinking bar cursor
# Verify: nvim cursor shape changes on mode switch (insert → bar, normal → block)
\`\`\`

## Verification checklist
- [ ] Ghostty starts without errors
- [ ] Font renders with Nerd Font icons
- [ ] Blinking bar cursor visible
- [ ] Nvim cursor shape changes on mode switch

Closes CAL-91