### PR TITLE
feat(CAL-108): replace alpha dashboard with useful quick-action layout

### DIFF
--- a/nvim/lua/cthayer/plugins/alpha.lua
+++ b/nvim/lua/cthayer/plugins/alpha.lua
@@ -1,9 +1,9 @@
 -- ------------------------------------------------------------------------------
 -- alpha-nvim (goolord/alpha-nvim) — Startup dashboard
 -- ------------------------------------------------------------------------------
--- What it does: Shows a startup screen with Neovim logo, quick-action buttons
---   (new file, find file, recent files, config, quit) and plugin load stats.
--- Keymaps: Dashboard buttons e, f, r, c, q (defined in config below).
+-- What it does: Shows a startup screen with time-of-day greeting, date, cwd,
+--   quick-action buttons, and lazy.nvim plugin stats in the footer.
+-- Keymaps: n e f F w r b g t p c l q (see buttons below).
 -- Notes: Uses dashboard theme; depends on nvim-web-devicons for icons.
 -- ------------------------------------------------------------------------------
 
@@ -16,46 +16,61 @@ return {
 		local dashboard = require("alpha.themes.dashboard")
 
 		-- ------------------------------------------------------------------------------
-		-- 🎨 Header (ASCII Art Logo)
+		-- 🌅 Header: greeting + date + cwd
 		-- ------------------------------------------------------------------------------
+		local function greeting()
+			local hour = tonumber(os.date("%H"))
+			if hour < 5 then return "  Still up?" end
+			if hour < 12 then return "  Good morning" end
+			if hour < 17 then return "  Good afternoon" end
+			if hour < 21 then return "  Good evening" end
+			return "  Good night"
+		end
+
 		dashboard.section.header.val = {
-			"                                                     ",
-			"  ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗ ",
-			"  ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║ ",
-			"  ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║ ",
-			"  ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║ ",
-			"  ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║ ",
-			"  ╚═╝  ╚═══╝╚══════╝ ╚═════╝   ╚═══╝  ╚═╝╚═╝     ╚═╝ ",
-			"                                                     ",
+			"",
+			greeting(),
+			"  " .. os.date("%A, %B %d"),
+			"  " .. vim.fn.fnamemodify(vim.fn.getcwd(), ":~"),
+			"",
 		}
+		dashboard.section.header.opts = { hl = "AlphaHeader", position = "center" }
 
 		-- ------------------------------------------------------------------------------
 		-- 🛠 Buttons (Quick Actions)
 		-- ------------------------------------------------------------------------------
 		dashboard.section.buttons.val = {
-			dashboard.button("e", "  New File", ":ene <BAR> startinsert <CR>"),
-			dashboard.button("f", "󰈞  Find File", ":Telescope find_files<CR>"),
-			dashboard.button("r", "󰄉  Recent Files", ":Telescope oldfiles<CR>"),
-			dashboard.button("c", "  Config", ":e $MYVIMRC<CR>"),
-			dashboard.button("q", "  Quit", ":qa<CR>"),
+			dashboard.button("n", "  New file",        "<cmd>ene <BAR> startinsert<CR>"),
+			dashboard.button("e", "  Explorer",        "<cmd>Neotree toggle<CR>"),
+			dashboard.button("f", "  Find file",       "<cmd>Telescope find_files<CR>"),
+			dashboard.button("F", "  Git files",       "<cmd>Telescope git_files<CR>"),
+			dashboard.button("w", "  Find word",       "<cmd>Telescope live_grep<CR>"),
+			dashboard.button("r", "  Recent files",    "<cmd>Telescope oldfiles<CR>"),
+			dashboard.button("b", "  Git branches",   "<cmd>Telescope git_branches<CR>"),
+			dashboard.button("g", "  Git status",      "<cmd>LazyGit<CR>"),
+			dashboard.button("t", "  Find todos",      "<cmd>TodoTelescope<CR>"),
+			dashboard.button("p", "  Plugins",         "<cmd>Lazy<CR>"),
+			dashboard.button("c", "  Config",          "<cmd>e $MYVIMRC<CR>"),
+			dashboard.button("l", "  Changelog",       "<cmd>LazyChangelog<CR>"),
+			dashboard.button("q", "  Quit",            "<cmd>qa<CR>"),
 		}
 
 		-- ------------------------------------------------------------------------------
-		-- 📈 Footer (Plugin Stats)
+		-- 📈 Footer: plugin count + pending updates
 		-- ------------------------------------------------------------------------------
-		dashboard.section.footer.val = function()
-			local stats = require("lazy").stats()
-			return "⚡ Neovim loaded "
-				.. stats.count
-				.. " plugins in "
-				.. math.floor(stats.startuptime * 100 + 0.5) / 100
-				.. "ms"
+		local function footer()
+			local ok, lazy = pcall(require, "lazy")
+			if not ok then return "" end
+			local stats = lazy.stats()
+			local updates = (stats.updates and stats.updates > 0)
+				and ("  " .. stats.updates .. " update" .. (stats.updates > 1 and "s" or "") .. " available")
+				or ""
+			return "⚡ " .. stats.loaded .. "/" .. stats.count .. " plugins loaded" .. updates
 		end
-		dashboard.section.footer.opts.hl = "Comment"
 
-		-- ------------------------------------------------------------------------------
-		-- 🚀 Setup Alpha
-		-- ------------------------------------------------------------------------------
+		dashboard.section.footer.val = footer()
+		dashboard.section.footer.opts = { hl = "AlphaFooter", position = "center" }
+
 		alpha.setup(dashboard.config)
 	end,
 }


### PR DESCRIPTION
## What changed
**`nvim/lua/cthayer/plugins/alpha.lua`** — complete overhaul:
- **Header**: Time-of-day greeting + current date + cwd
- **13 buttons**: n(new) e(explorer) f(find files) F(git files) w(grep) r(recent) b(branches) g(lazygit) t(todos) p(plugins) c(config) l(changelog) q(quit)
- **Footer**: `X/Y plugins loaded` + pending update count from lazy.nvim

## How to test
\`\`\`
nvim           # open without file arg
# Verify header shows greeting + date + cwd
# Test: F → git files picker, b → branch picker, g → lazygit
\`\`\`

## Verification checklist
- [ ] Dashboard renders on `nvim` (no file arg)
- [ ] All 13 buttons visible and functional
- [ ] `F` opens git files (different from `f`)
- [ ] Footer shows plugin count

Closes CAL-108