### PR TITLE
fix(CAL-101): fix <leader>rs — :lsp restart is not a valid Neovim command

### DIFF
--- a/nvim/lua/cthayer/plugins/lspconfig.lua
+++ b/nvim/lua/cthayer/plugins/lspconfig.lua
@@ -62,7 +62,7 @@ return {
 				keymap.set("n", "[d", vim.diagnostic.goto_prev, { desc = "Prev diagnostic", unpack(opts) })
 				keymap.set("n", "]d", vim.diagnostic.goto_next, { desc = "Next diagnostic", unpack(opts) })
 				keymap.set("n", "K", vim.lsp.buf.hover, { desc = "Hover", unpack(opts) })
-				keymap.set("n", "<leader>rs", "<cmd>lsp restart<CR>", { desc = "Restart LSP", unpack(opts) })
+				keymap.set("n", "<leader>rs", "<cmd>LspRestart<CR>", { desc = "Restart LSP", unpack(opts) })
 				-- Svelte: notify server on TS/JS file changes (replaces old on_attach)
 				if client.name == "svelte" then
 					vim.api.nvim_create_autocmd("BufWritePost", {


### PR DESCRIPTION
## What changed
- `nvim/lua/cthayer/plugins/lspconfig.lua` line 65: replaced `<cmd>lsp restart<CR>` with `<cmd>LspRestart<CR>`

`:lsp restart` is not a valid Neovim command — it throws `E492: Not an editor command`. The correct command provided by nvim-lspconfig is `:LspRestart`.

## How to test
1. `git checkout fix/cal-101-lsp-restart && nvim`
2. Open any file that triggers an LSP (e.g. a `.lua` file)
3. Press `<leader>rs` — LSP should restart without error

## Verification checklist
- [x] `<leader>rs` calls `:LspRestart` (valid nvim-lspconfig command)
- [x] No `E492: Not an editor command` on keymap trigger

Closes CAL-101