### PR TITLE
fix(CAL-97): remove broken fzf-history widget using Bash readline vars in Zsh

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -88,18 +88,6 @@ fi
 export FZF_TMUX=1
 export FZF_TMUX_HEIGHT=40%
 
-# Ctrl+R: search history with fzf and put result on command line
-fzf-history() {
-  local selected
-  selected=$(history | fzf | awk '{$1=""; print substr($0,2)}')
-  if [[ -n "$selected" ]]; then
-    READLINE_LINE=$selected
-    READLINE_POINT=${#selected}
-  fi
-}
-zle -N fzf-history
-bindkey '^R' fzf-history
-
 # pyenv + pyenv-virtualenv: Python version and venv switching
 if command -v pyenv &>/dev/null; then
   eval "$(pyenv init -)"


### PR DESCRIPTION
## What changed
- `zsh/.zshrc`: removed the custom `fzf-history` function and its `zle -N` / `bindkey` lines (11 lines deleted)

## Why
`READLINE_LINE` and `READLINE_POINT` are Bash readline variables — they have no effect in Zsh's ZLE. The widget appeared to work (no error) but silently discarded the fzf selection without placing it on the command line.

The sourced `key-bindings.zsh` from fzf already registers a correct `fzf-history-widget` on `Ctrl+R` using ZLE's `BUFFER`/`CURSOR`. The custom widget was a broken duplicate.

## How to test
1. `git checkout fix/cal-97-fzf-history-zle && source ~/.zshrc`
2. Press `Ctrl+R` — fzf history search should open and selecting an entry places it on the command line
3. Confirm no orphaned `bindkey '^R'` entry: `bindkey | grep '\^R'` should show fzf's widget

## Verification checklist
- [x] Removed `READLINE_LINE`/`READLINE_POINT` widget
- [x] `Ctrl+R` still works via fzf's native `key-bindings.zsh`
- [x] No duplicate `bindkey '^R'` registrations

Closes CAL-97