### PR TITLE
fix(CAL-89): remove EOL packages from Brewfile (exa, node@16, python@3.8/3.9)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -33,7 +33,6 @@ brew "bzip2"                  # Freely available high-quality data compressor
 brew "coreutils"              # GNU core utilities (grealpath, gsort, etc.)
 brew "cscope"                 # Code browsing and navigation tool
 brew "curl"                   # Get a file from HTTP, HTTPS or FTP servers
-brew "exa"                    # Modern replacement for ls (legacy; eza is the maintained fork)
 brew "eza"                    # Modern, maintained replacement for ls with icons and colors
 brew "fnm"                    # Fast and simple Node.js version manager
 brew "fzf"                    # Command-line fuzzy finder written in Go
@@ -79,7 +78,6 @@ brew "go"                     # Open source programming language (Go)
 brew "macvim"                 # GUI for vim, made for macOS
 brew "neovim"                 # Ambitious Vim-fork focused on extensibility and agility
 brew "node"                   # Open-source, cross-platform JavaScript runtime (Node.js)
-brew "node@16"                # Node.js 16 LTS (platform built on V8)
 brew "r"                      # Software environment for statistical computing
 brew "rust"                   # Safe, concurrent, practical systems language
 brew "yarn"                   # JavaScript package manager
@@ -92,8 +90,6 @@ brew "pipenv"                 # Python dependency management via Pipfile
 brew "poetry"                 # Python package management tool
 brew "pyenv"                  # Python version management
 brew "pyenv-virtualenv"       # Pyenv plugin to manage virtualenv
-brew "python@3.8"             # Interpreted, interactive, object-oriented programming language
-brew "python@3.9"             # Interpreted, interactive, object-oriented programming language
 brew "python@3.10"            # Interpreted, interactive, object-oriented programming language
 brew "python@3.11"            # Interpreted, interactive, object-oriented programming language
 brew "python@3.13"            # Interpreted, interactive, object-oriented programming language


### PR DESCRIPTION
## What changed
- `Brewfile`: removed 4 abandoned/EOL formulae

| Removed | Reason |
|---------|--------|
| `exa` | Abandoned Jan 2023; `eza` (maintained fork) already present in Brewfile |
| `node@16` | EOL April 2023; `node` (current LTS) already present |
| `python@3.8` | EOL October 2024 |
| `python@3.9` | EOL October 2025 |

## How to test
1. `git checkout fix/cal-89-brewfile-eol`
2. `brew bundle check` — should pass without errors on the updated Brewfile
3. Confirm `exa`, `node@16`, `python@3.8`, `python@3.9` no longer listed

## Verification checklist
- [x] `exa` removed (eza still present)
- [x] `node@16` removed (node still present)
- [x] `python@3.8` removed
- [x] `python@3.9` removed
- [x] python@3.10, 3.11, 3.13 retained

Closes CAL-89