### PR TITLE
fix(CAL-94): remove dead p10k symlink and Powerline fonts install from setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@
 #   3. Backup existing dotfiles to ~/.dotfiles-backup.YYYYMMDD (if present).
 #   4. Install Homebrew if missing; run brew bundle (Brewfile).
 #   5. Create symlinks: .zshrc, .zprofile, aliases, functions, tmux, fzf, git,
-#      nvim, starship, kitty, optional p10k.
+#      nvim, starship, kitty.
 #   6. Optional: Powerline fonts, Oh My Zsh (KEEP_ZSHRC=yes), fzf install, TPM,
 #      TPM plugin install, pyenv + Python.
 #   7. Print next steps (exec $SHELL, prefix+I in tmux).
@@ -135,22 +135,8 @@ ln -sf "$REPO/nvim" "$HOME/.config/nvim"
 # Prompt: Starship looks for ~/.config/starship.toml by default
 ln -sf "$REPO/starship/starship.toml" "$HOME/.config/starship.toml"
 
-# Optional: Powerlevel10k (commented out in .zshrc; uncomment to use)
-ln -sf "$REPO/powerline/.p10k.zsh" "$HOME/.p10k.zsh" 2>/dev/null || true
-
 # Terminals
 ln -sf "$REPO/kitty" "$HOME/.config/kitty"
-
-# ------------------------------------------------------------------------------
-# 🔤 Powerline fonts: optional, improves prompt/icons in some terminals.
-# ------------------------------------------------------------------------------
-if [[ ! -d "$HOME/fonts" ]] && [[ ! -d "$HOME/.local/share/fonts" ]]; then
-  if git clone https://github.com/powerline/fonts.git --depth=1 "$HOME/fonts" 2>/dev/null; then
-    log "Installing Powerline fonts..."
-    "$HOME/fonts/install.sh" || true
-    rm -rf "$HOME/fonts"
-  fi
-fi
 
 # ------------------------------------------------------------------------------
 # 🎨 Oh My Zsh: keep existing .zshrc (our symlink) — do not overwrite.


### PR DESCRIPTION
## What changed
- `setup.sh`: removed `ln -sf "$REPO/powerline/.p10k.zsh" "$HOME/.p10k.zsh"` (dead symlink)
- `setup.sh`: removed Powerline fonts git clone + install block (11 lines)
- `setup.sh`: updated header comment to remove p10k reference

## Why
The prompt is Starship, not Powerlevel10k. Every fresh `setup.sh` run was silently writing a stale `~/.p10k.zsh` symlink pointing at `powerline/.p10k.zsh` (which doesn't exist in the repo). The Powerline fonts block cloned a separate repo and ran an installer that targets non-Nerd-Font terminals — irrelevant for a Ghostty + Nerd Font setup.

## How to test
1. `git checkout fix/cal-94-setup-powerline`
2. Run `bash setup.sh` (or dry-run inspect)
3. Confirm `~/.p10k.zsh` is NOT created
4. Confirm no Powerline fonts clone attempt

## Verification checklist
- [x] `ln -sf ... .p10k.zsh` line removed
- [x] Powerline fonts block removed
- [x] Header comment updated
- [x] Starship symlink (`~/.config/starship.toml`) still present

Closes CAL-94