### PR TITLE
fix(CAL-92): align starship.toml module style fields with format string transition colors

### DIFF
--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -132,11 +132,11 @@ truncation_symbol = "…/"
 
 [git_branch]
 symbol = ""
-style = "bg:teal"
+style = "bg:green"
 format = '[[ $symbol $branch ](fg:base bg:green)]($style)'
 
 [git_status]
-style = "bg:teal"
+style = "bg:green"
 format = '[[($all_status)](fg:base bg:green)]($style)'
 conflicted = " "  # Git conflict icon
 ahead = " "        # Rocket icon
@@ -190,12 +190,13 @@ format = '[[ $symbol( $context) ](fg:#83a598 bg:color_bg3)]($style)'
 [gcloud]
 symbol = "󰅟"
 format = '[[ $symbol( $project) ](fg:black bg:yellow)]($style)'
-style = "bright-yellow"
+style = "bg:yellow"
 disabled = false
 
 [kubernetes]
 symbol = "󱃾"
 format = '[[ $symbol( $context) ](fg:black bg:blue)]($style)'
+style = "bg:blue"
 disabled = false
 
 # ------------------------------------------------------------------------------
@@ -205,7 +206,7 @@ disabled = false
 [time]
 disabled = false
 time_format = "%R"
-style = "bg:peach"
+style = "bg:purple"
 format = '[[  $time ](fg:mantle bg:purple)]($style)'
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## What changed
- `starship/starship.toml`: fixed 5 module `style` mismatches

## Why
Starship powerline separators in the `format` string declare the background color of each segment via `[](fg:prev bg:next)`. Each module's `style` field must match the `bg:` color the format string assigns it, or the powerline arrow renders the wrong color (the separator's background won't match the adjacent segment).

## Fixes

| Module | Was | Should be | Format string expects |
|--------|-----|-----------|-----------------------|
| `git_branch` | `bg:teal` | `bg:green` | `[](fg:peach bg:green)` |
| `git_status` | `bg:teal` | `bg:green` | `[](fg:peach bg:green)` |
| `gcloud` | `bright-yellow` | `bg:yellow` | `[](fg:blue bg:yellow)` |
| `kubernetes` | _(missing)_ | `bg:blue` | `[](fg:teal bg:blue)` |
| `time` | `bg:peach` | `bg:purple` | `[](fg:yellow bg:purple)` |

## How to test
1. `git checkout fix/cal-92-starship-colors`
2. Open a new shell — the prompt powerline segments should render with correct colors all the way through (no color breaks between arrows and segment backgrounds)

## Verification checklist
- [x] `git_branch` style matches format string (green)
- [x] `git_status` style matches format string (green)
- [x] `gcloud` style matches format string (yellow)
- [x] `kubernetes` style added (blue)
- [x] `time` style matches format string (purple)

Closes CAL-92