### PR TITLE
feat(CAL-122): add render-markdown.nvim for inline markdown rendering

### DIFF
--- a/nvim/lua/cthayer/plugins/render-markdown.lua
+++ b/nvim/lua/cthayer/plugins/render-markdown.lua
@@ -1,0 +1,80 @@
+-- ------------------------------------------------------------------------------
+-- render-markdown.nvim (MeanderingProgrammer/render-markdown.nvim)
+-- ------------------------------------------------------------------------------
+-- What it does: Renders markdown inline in Neovim buffers — no preview split,
+--   no mode switch. Headers get visual hierarchy, bullets use real symbols,
+--   code blocks get a background + syntax highlight, tables align, bold/italic
+--   render in normal mode.
+-- Notes: file_types includes "octo" so PR descriptions and issue bodies in
+--   octo.nvim render as formatted markdown automatically.
+-- Depends on: nvim-treesitter (markdown parser), nvim-web-devicons (icons).
+-- ------------------------------------------------------------------------------
+
+return {
+	"MeanderingProgrammer/render-markdown.nvim",
+	dependencies = {
+		"nvim-treesitter/nvim-treesitter",
+		"nvim-tree/nvim-web-devicons",
+	},
+	ft = { "markdown", "octo", "gitcommit", "Avante" },
+	opts = {
+		-- Enable for markdown files and octo.nvim PR/issue buffers
+		file_types = { "markdown", "octo", "gitcommit" },
+
+		-- Render mode: only show formatting in normal mode (not while editing)
+		render_modes = { "n", "c" },
+
+		-- Headings: progressively indented with level icons
+		heading = {
+			enabled = true,
+			sign = false, -- don't show sign column icon (clutters octo buffers)
+			icons = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+		},
+
+		-- Bullet list symbols (cycle through levels)
+		bullet = {
+			enabled = true,
+			icons = { "●", "○", "◆", "◇" },
+		},
+
+		-- Code blocks: add background highlight and language badge
+		code = {
+			enabled = true,
+			sign = false,
+			style = "full",    -- "full" = language label + background on whole block
+			border = "thin",
+			above = "▄",
+			below = "▀",
+		},
+
+		-- Horizontal rules rendered as a full-width line
+		dash = {
+			enabled = true,
+			icon = "─",
+			width = "full",
+		},
+
+		-- Checkboxes in task lists
+		checkbox = {
+			enabled = true,
+			unchecked = { icon = "󰄱 " },
+			checked   = { icon = "󰱒 " },
+		},
+
+		-- Tables: pad columns, add border characters
+		pipe_table = {
+			enabled = true,
+			style = "full",
+		},
+
+		-- Inline code: subtle highlight
+		inline_highlight = { enabled = true },
+
+		-- Links: show icon before URLs
+		link = {
+			enabled = true,
+			image = "󰥶 ",
+			hyperlink = "󰌹 ",
+		},
+	},
+}


### PR DESCRIPTION
## What changed
- `nvim/lua/cthayer/plugins/render-markdown.lua` — new plugin (80 lines)

## What it does

Renders markdown inline in Neovim normal mode — no preview split, no extra keybind. Raw markdown is visible while editing (insert mode), formatted view snaps back when you leave insert.

| Element | Rendering |
|---------|-----------|
| Headings | Progressive indent + level icons (󰲡 󰲣 󰲥…) |
| Bullets | Real symbols per nesting level (● ○ ◆ ◇) |
| Code blocks | Language badge + full background highlight |
| Task lists | Checkbox icons (󰄱 unchecked / 󰱒 checked) |
| Tables | Full borders, aligned columns |
| Links | Icon prefix (󰌹 ) |
| HR | Full-width `─` line |

## Key detail — works with octo.nvim

`file_types` includes `"octo"` so PR descriptions, issue bodies, and review comments in octo.nvim all render as formatted markdown automatically. Open any PR with `:Octo pr list` and the description will be visually formatted.

## How to test
1. `git checkout feat/cal-122-render-markdown`
2. Open any `.md` file in nvim — should render formatted in normal mode, raw in insert
3. `:Octo pr list` → open a PR → description should render with headers, bullets, code blocks

Closes CAL-122