### PR TITLE
feat(CAL-111): add diffview.nvim — rich git diff and merge conflict UI

### DIFF
--- a/nvim/lua/cthayer/plugins/diffview.lua
+++ b/nvim/lua/cthayer/plugins/diffview.lua
@@ -1,0 +1,49 @@
+-- ------------------------------------------------------------------------------
+-- diffview.nvim (sindrets/diffview.nvim) — Git diff and merge conflict UI
+-- ------------------------------------------------------------------------------
+-- What it does: Opens a rich diff view for any git range, a file history panel
+--   for blame-style exploration, and a 3-way merge conflict editor with layout
+--   controls. Replaces the need for external diff tools during code review.
+-- Keymaps:
+--   <leader>gd  — diff working tree vs HEAD (opens DiffviewOpen)
+--   <leader>gh  — file history for current buffer
+--   <leader>gH  — file history for entire repo
+--   <leader>gc  — close diffview (DiffviewClose)
+-- Notes: Lazy-loaded on keymaps and commands; zero startup cost.
+-- Depends on: nvim-web-devicons (icons), plenary.nvim (async).
+-- ------------------------------------------------------------------------------
+
+return {
+	"sindrets/diffview.nvim",
+	dependencies = {
+		"nvim-lua/plenary.nvim",
+		"nvim-tree/nvim-web-devicons",
+	},
+	cmd = { "DiffviewOpen", "DiffviewClose", "DiffviewToggleFiles", "DiffviewFileHistory" },
+	keys = {
+		{ "<leader>gd", "<cmd>DiffviewOpen<CR>",                desc = "Diffview: open diff (HEAD)" },
+		{ "<leader>gh", "<cmd>DiffviewFileHistory %<CR>",       desc = "Diffview: file history" },
+		{ "<leader>gH", "<cmd>DiffviewFileHistory<CR>",         desc = "Diffview: repo history" },
+		{ "<leader>gc", "<cmd>DiffviewClose<CR>",               desc = "Diffview: close" },
+	},
+	opts = {
+		enhanced_diff_hl = true,  -- use treesitter for inline diff highlights
+
+		view = {
+			-- 3-way layout for merge conflicts: ours | result | theirs
+			merge_tool = {
+				layout = "diff3_mixed",
+				disable_diagnostics = true,
+			},
+		},
+
+		hooks = {
+			-- When diffview opens, use the familiar Neovim diff mappings
+			diff_buf_read = function(bufnr)
+				vim.opt_local.wrap = false
+				vim.opt_local.list = false
+				vim.opt_local.colorcolumn = ""
+			end,
+		},
+	},
+}


### PR DESCRIPTION
## What changed

- **`nvim/lua/cthayer/plugins/diffview.lua`** — New plugin: `diffview.nvim` provides a full-panel git diff and merge conflict UI
  - `<leader>gd` — diff working tree vs HEAD (DiffviewOpen)
  - `<leader>gh` — file history for current buffer (blame-style exploration)
  - `<leader>gH` — file history for entire repo
  - `<leader>gc` — close diffview
  - 3-way merge conflict layout (`diff3_mixed`): ours | result | theirs
  - `enhanced_diff_hl = true` for treesitter-powered inline diff highlights
  - Lazy-loaded on keymaps/commands — zero startup cost

## How to test

```bash
git fetch origin && git checkout feat/cal-111-diffview
```

1. Open Neovim in any git repo
2. Press `<leader>gd` — full diff panel should open showing working tree changes
3. Press `<leader>gh` on a file — per-file git history should appear
4. Navigate to a file with merge conflicts, press `<leader>gd` — 3-way merge view should open
5. Press `<leader>gc` to close

## Verification checklist

- [ ] `<leader>gd` opens DiffviewOpen with working tree diff
- [ ] `<leader>gh` shows per-buffer file history
- [ ] `<leader>gH` shows full repo history
- [ ] `<leader>gc` closes the panel
- [ ] No errors on startup (`:checkhealth`)
- [ ] Lazy-loaded — only activates when keymaps are used

## Linear

Closes CAL-111