### PR TITLE
feat(CAL-110): add neotest — unified test runner with inline results

### DIFF
--- a/nvim/lua/cthayer/plugins/neotest.lua
+++ b/nvim/lua/cthayer/plugins/neotest.lua
@@ -1,0 +1,84 @@
+-- ------------------------------------------------------------------------------
+-- neotest (nvim-neotest/neotest) — Test runner framework for Neovim
+-- ------------------------------------------------------------------------------
+-- What it does: Unified test runner UI that works with multiple test frameworks.
+--   Runs tests in the background, shows results inline (pass/fail signs in the
+--   gutter), surfaces output/errors in a split, and integrates with nvim-dap
+--   for debugging individual tests.
+-- Keymaps (all under <leader>T):
+--   <leader>Tr  — run nearest test
+--   <leader>TT  — run all tests in file
+--   <leader>Ts  — toggle test summary panel
+--   <leader>To  — show test output for nearest test
+--   <leader>TO  — open output in a floating window
+--   <leader>Td  — debug nearest test (requires nvim-dap)
+--   <leader>Tx  — stop running tests
+-- Adapters bundled:
+--   neotest-python   — pytest / unittest
+--   neotest-go       — go test
+--   neotest-jest     — Jest (JS/TS)
+--   neotest-vitest   — Vitest (JS/TS)
+-- Notes: Adapters are lazy-loaded; only the ones matching the current file type
+--   actually run. Additional adapters can be added to the adapters list.
+-- Depends on: nvim-nio, plenary, nvim-treesitter.
+-- ------------------------------------------------------------------------------
+
+return {
+	"nvim-neotest/neotest",
+	dependencies = {
+		"nvim-neotest/nvim-nio",
+		"nvim-lua/plenary.nvim",
+		"antoinemadec/FixCursorHold.nvim",
+		"nvim-treesitter/nvim-treesitter",
+		-- Language adapters
+		"nvim-neotest/neotest-python",
+		"nvim-neotest/neotest-go",
+		"marilari88/neotest-vitest",
+		{ "haydenmeade/neotest-jest", lazy = true },
+	},
+	keys = {
+		{ "<leader>Tr", function() require("neotest").run.run() end,                          desc = "Neotest: run nearest test" },
+		{ "<leader>TT", function() require("neotest").run.run(vim.fn.expand("%")) end,        desc = "Neotest: run file" },
+		{ "<leader>Ts", function() require("neotest").summary.toggle() end,                   desc = "Neotest: toggle summary" },
+		{ "<leader>To", function() require("neotest").output.open({ enter = true }) end,      desc = "Neotest: show output" },
+		{ "<leader>TO", function() require("neotest").output_panel.toggle() end,              desc = "Neotest: toggle output panel" },
+		{ "<leader>Td", function() require("neotest").run.run({ strategy = "dap" }) end,      desc = "Neotest: debug nearest test" },
+		{ "<leader>Tx", function() require("neotest").run.stop() end,                         desc = "Neotest: stop tests" },
+	},
+	config = function()
+		require("neotest").setup({
+			adapters = {
+				require("neotest-python")({
+					dap = { justMyCode = false },
+					runner = "pytest",
+				}),
+				require("neotest-go")({
+					experimental = { test_table = true },
+				}),
+				require("neotest-jest")({
+					jestCommand = "npx jest",
+					jestConfigFile = "jest.config.js",
+				}),
+				require("neotest-vitest"),
+			},
+
+			-- Show diagnostics inline for failed tests
+			diagnostic = {
+				enabled = true,
+				severity = vim.diagnostic.severity.ERROR,
+			},
+
+			-- Status icons in sign column
+			icons = {
+				passed    = "✓",
+				failed    = "✗",
+				running   = "◌",
+				skipped   = "○",
+				unknown   = "?",
+				watching  = "◎",
+			},
+
+			output = { open_on_run = false },  -- don't auto-open; use <leader>To
+		})
+	end,
+}

--- a/nvim/lua/cthayer/plugins/which-key.lua
+++ b/nvim/lua/cthayer/plugins/which-key.lua
@@ -24,6 +24,7 @@ return {
 		{ "<leader>o", name = "+oil" },
 		{ "<leader>r", name = "+refactor/LSP" },
 		{ "<leader>t", name = "+tab/term/todo" },
+		{ "<leader>T", name = "+neotest" },
 		{ "<leader>u", name = "+undo/inlay" },
 		{ "<leader>z", name = "+no-neck-pain" },
 	},


### PR DESCRIPTION
## What changed

- **`nvim/lua/cthayer/plugins/neotest.lua`** — New plugin: `neotest` with adapters for pytest, go test, Jest, and Vitest
  - Tests run in the background; pass/fail signs appear in gutter (✓/✗)
  - Summary panel shows all tests in the project tree (`<leader>Ts`)
  - Output accessible per-test (`<leader>To`) or as a persistent panel (`<leader>TO`)
  - Debug individual tests via nvim-dap with `<leader>Td` (requires dap adapters)
  - Adapters: `neotest-python` (pytest), `neotest-go`, `neotest-jest`, `neotest-vitest`
  - Keymaps under `<leader>T`

- **`nvim/lua/cthayer/plugins/which-key.lua`** — Added `<leader>T` group label `+neotest`

## How to test

```bash
git fetch origin && git checkout feat/cal-110-neotest
```

1. Open a Python test file (`test_*.py`) in Neovim
2. Press `<leader>Tr` on a test function — it should run and show ✓/✗ in the gutter
3. Press `<leader>TT` — all tests in the file should run
4. Press `<leader>Ts` — test summary tree should open
5. Press `<leader>To` — test output/errors should display

## Verification checklist

- [ ] `<leader>T` shows `+neotest` group in which-key popup
- [ ] `<leader>Tr` runs nearest test with gutter sign feedback
- [ ] `<leader>TT` runs all tests in current file
- [ ] `<leader>Ts` toggles the summary panel
- [ ] `<leader>To` shows test output
- [ ] No errors on startup

## Linear

Closes CAL-110