### PR TITLE
feat(CAL-112): add nvim-spectre — project-wide find and replace

### DIFF
--- a/nvim/lua/cthayer/plugins/spectre.lua
+++ b/nvim/lua/cthayer/plugins/spectre.lua
@@ -1,0 +1,35 @@
+-- ------------------------------------------------------------------------------
+-- nvim-spectre (nvim-pack/nvim-spectre) — Project-wide find and replace
+-- ------------------------------------------------------------------------------
+-- What it does: Opens a search/replace panel that shows all matches across the
+--   project (powered by ripgrep) with a live preview. Replacements can be
+--   applied per-match, per-file, or all at once. Supports regex and plain text,
+--   case sensitivity, and file-type filters.
+-- Keymaps:
+--   <leader>S   — open Spectre (project-wide search)
+--   <leader>sw  — search current word across project
+--   <leader>sf  — search in current file only
+-- Notes: Requires ripgrep (rg) and sed/oxi-replace for substitutions.
+--   Both are available via Homebrew and declared in Brewfile.
+-- ------------------------------------------------------------------------------
+
+return {
+	"nvim-pack/nvim-spectre",
+	dependencies = { "nvim-lua/plenary.nvim" },
+	cmd = "Spectre",
+	keys = {
+		{ "<leader>S",  function() require("spectre").toggle() end,                                    desc = "Spectre: project-wide find/replace" },
+		{ "<leader>sw", function() require("spectre").open_visual({ select_word = true }) end,         desc = "Spectre: search current word", mode = { "n" } },
+		{ "<leader>sw", function() require("spectre").open_visual() end,                               desc = "Spectre: search selection",   mode = { "v" } },
+		{ "<leader>sf", function() require("spectre").open_file_search({ select_word = true }) end,    desc = "Spectre: search in file" },
+	},
+	opts = {
+		open_cmd = "noswapfile vnew",
+		live_update = false,  -- manual refresh to avoid hammering rg on large repos
+		highlight = {
+			ui      = "String",
+			search  = "DiffChange",
+			replace = "DiffDelete",
+		},
+	},
+}


### PR DESCRIPTION
## What changed

- **`nvim/lua/cthayer/plugins/spectre.lua`** — New plugin: `nvim-spectre` for project-wide search and replace
  - Powered by ripgrep — fast across large repos
  - `<leader>S` — open Spectre panel
  - `<leader>sw` — search current word (or visual selection) across project
  - `<leader>sf` — search in current file only
  - Supports regex, case sensitivity toggle, file-type filters
  - Apply replacements per-match, per-file, or all at once
  - `live_update = false` to avoid hammering rg on large repos

## How to test

```bash
git fetch origin && git checkout feat/cal-112-spectre
```

1. Open Neovim in a project directory
2. Press `<leader>S` — Spectre panel should open as a vertical split
3. Type a search term, press Enter — matches shown with file paths and line numbers
4. Type a replacement, navigate to a match, press `<leader>r` to replace

## Verification checklist

- [ ] `<leader>S` opens Spectre panel
- [ ] `<leader>sw` on a word pre-fills the search
- [ ] Matches appear with ripgrep results across files
- [ ] Replace works on individual matches
- [ ] No errors on startup

## Linear

Closes CAL-112