### PR TITLE
feat(CAL-113): add zoxide — frecency-based directory jumping

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -40,6 +40,7 @@ brew "fzf"                    # Command-line fuzzy finder written in Go
 brew "jq"                     # Lightweight and flexible command-line JSON processor
 brew "ripgrep"                # Search tool like grep and The Silver Searcher
 brew "tree"                   # Display directories as trees (with optional color/HTML output)
+brew "zoxide"                 # Smarter cd — jumps to frecently used dirs; replaces autojump/z
 brew "wget"                   # Internet file retriever
 brew "xz"                     # General-purpose data compression with high compression ratio
 brew "zstd"                   # Zstandard real-time compression algorithm

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -81,6 +81,12 @@ if command -v direnv &>/dev/null; then
   eval "$(direnv hook zsh)"
 fi
 
+# zoxide: smarter cd — jump to frecently visited dirs with `z` and `zi` (interactive)
+# Install: brew install zoxide  |  Usage: z <partial-path>, zi (fzf picker)
+if command -v zoxide &>/dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
 # fzf: fuzzy finder key bindings (sourced from repo: ~/.fzf → repo/fzf/.fzf)
 if [[ -f "$HOME/.fzf/key-bindings.zsh" ]]; then
   source "$HOME/.fzf/key-bindings.zsh"


### PR DESCRIPTION
## What changed

- **`zsh/.zshrc`** — Added zoxide init (guarded with `command -v`, no-op if not installed)
  - `z <partial>` — jump to the most frecently used directory matching the pattern
  - `zi` — opens an interactive fzf picker over the full directory history
- **`Brewfile`** — Added `brew "zoxide"` so `brew bundle` installs it automatically

## How to test

```bash
git fetch origin && git checkout feat/cal-113-zoxide
brew bundle --file=Brewfile  # installs zoxide if not present
source ~/.zshrc
```

1. `cd` to a few different directories to build up history
2. Run `z <partial-name>` — should jump to the closest frecently matched dir
3. Run `zi` — should open an fzf picker showing recent directories

## Verification checklist

- [ ] `zoxide` is in Brewfile
- [ ] `.zshrc` initializes zoxide only if binary is present
- [ ] `z` command jumps to a frecently visited directory
- [ ] `zi` opens interactive fzf picker
- [ ] Shell starts without error if zoxide is not yet installed

## Linear

Closes CAL-113