### PR TITLE
feat(CAL-116): add tmux-sessionizer — fzf-powered project session switcher

### DIFF
--- a/scripts/tmux-sessionizer
+++ b/scripts/tmux-sessionizer
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------------------------
+# tmux-sessionizer — Fuzzy-jump to (or create) a tmux session per project dir
+# ------------------------------------------------------------------------------
+# What it does:
+#   Uses fzf to pick a directory from a list of common project roots.
+#   If a tmux session already exists for that directory, switch to it.
+#   If not, create a new session named after the directory's basename.
+#
+# Usage:
+#   tmux-sessionizer              — fzf picker of project directories
+#   tmux-sessionizer <path>       — jump directly without picker
+#
+# Wired to tmux prefix+f (see .tmux.conf) and shell alias `ts`.
+#
+# Inspired by ThePrimeagen's workflow. Customize PROJECT_DIRS below.
+# ------------------------------------------------------------------------------
+
+PROJECT_DIRS=(
+  "$HOME"
+  "$HOME/projects"
+  "$HOME/work"
+  "$HOME/dev"
+  "$HOME/sys-config"
+)
+
+# If a path is passed directly, skip fzf
+if [[ $# -eq 1 ]]; then
+  selected="$1"
+else
+  # Build the directory list: expand each dir up to 2 levels deep, dedupe
+  dir_list=""
+  for base in "${PROJECT_DIRS[@]}"; do
+    [[ -d "$base" ]] || continue
+    # Include the base dir itself and immediate subdirectories
+    dir_list+="$base"$'\n'
+    while IFS= read -r d; do
+      dir_list+="$d"$'\n'
+    done < <(find "$base" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+  done
+
+  selected=$(echo "$dir_list" | sort -u | fzf \
+    --prompt="  session: " \
+    --height=50% \
+    --reverse \
+    --border=rounded \
+    --preview='ls --color=always {} 2>/dev/null || echo "(empty)"')
+fi
+
+[[ -z "$selected" ]] && exit 0
+
+# Derive session name: basename, replace dots with underscores (tmux dislikes dots)
+session_name=$(basename "$selected" | tr '.' '_')
+
+# If inside tmux already, switch-client; otherwise attach or create
+if [[ -z "$TMUX" ]]; then
+  # Outside tmux: create or attach
+  tmux new-session -As "$session_name" -c "$selected"
+else
+  # Inside tmux: switch to existing session or create new one
+  if ! tmux has-session -t "=$session_name" 2>/dev/null; then
+    tmux new-session -ds "$session_name" -c "$selected"
+  fi
+  tmux switch-client -t "=$session_name"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -141,6 +141,10 @@ ln -sf "$REPO/powerline/.p10k.zsh" "$HOME/.p10k.zsh" 2>/dev/null || true
 # Terminals
 ln -sf "$REPO/kitty" "$HOME/.config/kitty"
 
+# Scripts: link tmux-sessionizer (and any future scripts) to ~/.local/bin so they're on PATH
+mkdir -p "$HOME/.local/bin"
+ln -sf "$REPO/scripts/tmux-sessionizer" "$HOME/.local/bin/tmux-sessionizer"
+
 # ------------------------------------------------------------------------------
 # 🔤 Powerline fonts: optional, improves prompt/icons in some terminals.
 # ------------------------------------------------------------------------------

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -58,6 +58,10 @@ bind - split-window -v
 unbind r
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
 
+# tmux-sessionizer: fuzzy jump to project directory / create session (prefix + f)
+# Script must be on PATH — setup.sh links ~/sys-config/scripts/ to PATH via ~/.local/bin
+bind f run-shell "tmux-sessionizer"
+
 # ------------------------------------------------------------------------------
 # Copy-mode (scrollback and copy to clipboard)
 # ------------------------------------------------------------------------------

--- a/zsh/aliases.shrc
+++ b/zsh/aliases.shrc
@@ -92,6 +92,7 @@ alias gcpr="gh pr create -w"
 alias gsync="git checkout main && git pull --rebase && git fetch --prune"
 alias glom="git pull origin main"
 alias lg=lazygit
+alias ts=tmux-sessionizer  # fuzzy-jump to project dir / create tmux session
 alias ppp='security find-generic-password -s com.phillies.onboarding.generate-ssh-key -w'
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- **`scripts/tmux-sessionizer`** — New executable script: fuzzy-pick a project directory, switch to (or create) a dedicated tmux session for it
  - Searches `~/`, `~/projects`, `~/work`, `~/dev`, `~/sys-config` (customizable `PROJECT_DIRS` array)
  - If already inside tmux: switches to existing session or creates a new one
  - If outside tmux: creates/attaches to the session directly
  - Session names derived from directory basename (dots → underscores for tmux compatibility)
  - Accepts a path as argument to skip the fzf picker

- **`tmux/.tmux.conf`** — Added `prefix+f` keybinding to trigger sessionizer

- **`zsh/aliases.shrc`** — Added `ts` alias for `tmux-sessionizer`

- **`setup.sh`** — Creates `~/.local/bin/` and symlinks `scripts/tmux-sessionizer` there so it's on PATH after setup

## How to test

```bash
git fetch origin && git checkout feat/cal-116-tmux-sessionizer
bash setup.sh  # or: ln -sf ~/sys-config/scripts/tmux-sessionizer ~/.local/bin/tmux-sessionizer
```

Inside a tmux session:
1. Press `prefix+f` (Ctrl-A + f) — fzf picker should show project directories
2. Select a directory — tmux should switch to (or create) a session for it
3. Run `ts` from the shell — same picker

## Verification checklist

- [ ] `scripts/tmux-sessionizer` is executable and on PATH after setup
- [ ] `prefix+f` in tmux opens the fzf directory picker
- [ ] Selecting a new directory creates a fresh tmux session
- [ ] Selecting an existing session's directory switches to it
- [ ] `ts` alias works from the shell
- [ ] Script is a no-op if fzf is not installed (exits gracefully on empty selection)

## Linear

Closes CAL-116