### PR TITLE
feat(CAL-117): add yanky.nvim — yank ring with paste cycling

### DIFF
--- a/nvim/lua/cthayer/plugins/yanky.lua
+++ b/nvim/lua/cthayer/plugins/yanky.lua
@@ -1,0 +1,55 @@
+-- ------------------------------------------------------------------------------
+-- yanky.nvim (gbprod/yanky.nvim) — Yank ring and paste enhancements
+-- ------------------------------------------------------------------------------
+-- What it does: Maintains a yank history ring so you can cycle through previous
+--   yanks after pasting. Highlights the yanked region briefly. Integrates with
+--   Telescope for a fuzzy yank-history picker.
+-- Keymaps:
+--   p / P         — enhanced paste (replaces built-in; same behavior by default)
+--   <C-n> / <C-p> — after pasting, cycle to next/previous yank in ring
+--   y             — enhanced yank (same behavior, adds to ring)
+--   <leader>fy    — Telescope yank history picker
+-- Notes: Uses vim.highlight.on_yank internally (replaces autocmd approach).
+--   Ring is stored in memory per session; not persisted across restarts.
+-- Depends on: nvim-nio (for async operations), telescope.nvim (picker).
+-- ------------------------------------------------------------------------------
+
+return {
+	"gbprod/yanky.nvim",
+	dependencies = {
+		"nvim-telescope/telescope.nvim",
+		"nvim-lua/plenary.nvim",
+	},
+	keys = {
+		{ "y",          "<Plug>(YankyYank)",                 mode = { "n", "x" }, desc = "Yanky: yank" },
+		{ "p",          "<Plug>(YankyPutAfter)",             mode = { "n", "x" }, desc = "Yanky: paste after" },
+		{ "P",          "<Plug>(YankyPutBefore)",            mode = { "n", "x" }, desc = "Yanky: paste before" },
+		{ "gp",         "<Plug>(YankyGPutAfter)",            mode = { "n", "x" }, desc = "Yanky: gput after" },
+		{ "gP",         "<Plug>(YankyGPutBefore)",           mode = { "n", "x" }, desc = "Yanky: gput before" },
+		{ "<C-n>",      "<Plug>(YankyCycleForward)",                               desc = "Yanky: cycle forward in ring" },
+		{ "<C-p>",      "<Plug>(YankyCycleBackward)",                              desc = "Yanky: cycle backward in ring" },
+		{ "<leader>fy", function() require("telescope").extensions.yank_history.yank_history({}) end,
+		                                                                            desc = "Telescope: yank history" },
+	},
+
+	config = function()
+		require("yanky").setup({
+			ring = {
+				history_length    = 50,
+				storage           = "memory",  -- keep in memory (fast, no persistence)
+				sync_with_numbered_registers = true,
+			},
+			highlight = {
+				on_put  = true,
+				on_yank = true,
+				timer   = 150,  -- ms to highlight the yanked region
+			},
+		})
+
+		-- Register Telescope extension
+		local ok, telescope = pcall(require, "telescope")
+		if ok then
+			telescope.load_extension("yank_history")
+		end
+	end,
+}


### PR DESCRIPTION
## What changed

- **`nvim/lua/cthayer/plugins/yanky.lua`** — New plugin: `yanky.nvim` yank ring and enhanced paste
  - 50-entry yank history ring stored in memory
  - After pasting: `<C-n>` / `<C-p>` cycle forward/backward through previous yanks
  - Briefly highlights the yanked/pasted region (150ms) for visual confirmation
  - `<leader>fy` — Telescope picker over full yank history
  - Syncs with numbered registers (`"0` - `"9`)
  - Drop-in for `y`, `p`, `P` — same keymaps, enhanced behavior

## How to test

```bash
git fetch origin && git checkout feat/cal-117-yanky
```

1. Yank several different lines/words
2. Paste with `p` — the most recent yank appears
3. Press `<C-p>` — cycles to the previous yank
4. Press `<leader>fy` — Telescope shows full yank history
5. Verify yanked region briefly highlights

## Verification checklist

- [ ] `y`, `p`, `P` work as expected (no regression)
- [ ] `<C-n>` / `<C-p>` cycle through yank ring after paste
- [ ] `<leader>fy` opens Telescope yank history
- [ ] Yanked region flashes briefly on yank and paste
- [ ] No errors on startup

## Linear

Closes CAL-117