### PR TITLE
feat(CAL-118): add atuin — shell history with fuzzy TUI and statistics

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -36,6 +36,7 @@ brew "curl"                   # Get a file from HTTP, HTTPS or FTP servers
 brew "exa"                    # Modern replacement for ls (legacy; eza is the maintained fork)
 brew "eza"                    # Modern, maintained replacement for ls with icons and colors
 brew "fnm"                    # Fast and simple Node.js version manager
+brew "atuin"                  # Shell history with fuzzy search, stats, and optional cloud sync
 brew "fzf"                    # Command-line fuzzy finder written in Go
 brew "jq"                     # Lightweight and flexible command-line JSON processor
 brew "ripgrep"                # Search tool like grep and The Silver Searcher

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -100,6 +100,13 @@ fzf-history() {
 zle -N fzf-history
 bindkey '^R' fzf-history
 
+# atuin: shell history with fuzzy search TUI, stats, and optional sync
+# Ctrl+R opens atuin's TUI; replaces the fzf-history widget above if installed.
+# Install: brew install atuin  |  First run: atuin import auto
+if command -v atuin &>/dev/null; then
+  eval "$(atuin init zsh --disable-up-arrow)"
+fi
+
 # pyenv + pyenv-virtualenv: Python version and venv switching
 if command -v pyenv &>/dev/null; then
   eval "$(pyenv init -)"


### PR DESCRIPTION
## What changed

- **`zsh/.zshrc`** — Added atuin init (guarded with `command -v`, no-op if not installed)
  - `Ctrl+R` opens atuin's fuzzy history TUI instead of basic reverse-isearch
  - `--disable-up-arrow` preserves standard up-arrow for sequential history cycling
  - Features: per-directory history filtering, timestamps, exit codes, duration stats
- **`Brewfile`** — Added `brew "atuin"` so `brew bundle` installs it automatically

## How to test

```bash
git fetch origin && git checkout feat/cal-118-atuin
brew bundle --file=Brewfile  # installs atuin
atuin import auto            # import existing shell history on first run
source ~/.zshrc
```

1. Type a few commands
2. Press `Ctrl+R` — atuin's TUI should open showing history with timestamps and exit codes
3. Search with fuzzy text — results filter in real-time
4. In a project directory: history should prioritize commands run in that directory
5. Press `Esc` to cancel

## Verification checklist

- [ ] `atuin` is in Brewfile
- [ ] `.zshrc` initializes atuin only if binary is present
- [ ] `Ctrl+R` opens atuin TUI
- [ ] History items show timestamps and exit codes
- [ ] Up-arrow still cycles through history normally
- [ ] Shell starts without error if atuin is not yet installed

## Linear

Closes CAL-118