### PR TITLE
feat(CAL-119): add lazydocker — TUI for docker containers and images

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -66,6 +66,7 @@ brew "commitizen"             # Defines a standard way of committing (convention
 brew "gh"                     # GitHub command-line tool
 brew "git-delta"              # Syntax-highlighting pager for git and diff output
 brew "hub"                    # Add GitHub support to git on the command-line
+brew "lazydocker"             # Simple terminal UI for docker and docker-compose
 brew "lazygit"                # Simple terminal UI for git commands
 brew "pre-commit"             # Framework for managing multi-language pre-commit hooks
 brew "shellcheck"             # Static analysis and lint tool for (ba)sh scripts

--- a/zsh/aliases.shrc
+++ b/zsh/aliases.shrc
@@ -92,6 +92,7 @@ alias gcpr="gh pr create -w"
 alias gsync="git checkout main && git pull --rebase && git fetch --prune"
 alias glom="git pull origin main"
 alias lg=lazygit
+alias ld=lazydocker  # TUI for docker containers, logs, and images
 alias ppp='security find-generic-password -s com.phillies.onboarding.generate-ssh-key -w'
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- **`Brewfile`** — Added `brew "lazydocker"` for TUI docker management
- **`zsh/aliases.shrc`** — Added `ld` alias for `lazydocker`

lazydocker provides a full terminal UI for: viewing running/stopped containers, streaming logs, executing into containers, managing images and volumes, starting/stopping/removing containers, and viewing docker-compose services.

## How to test

```bash
git fetch origin && git checkout feat/cal-119-lazydocker
brew bundle --file=Brewfile  # installs lazydocker
```

1. With Docker running, type `ld` in the terminal
2. lazydocker TUI should open showing containers, images, and volumes
3. Navigate with arrow keys; `q` to quit

## Verification checklist

- [ ] `lazydocker` is in Brewfile
- [ ] `ld` alias works
- [ ] lazydocker TUI opens and shows docker state
- [ ] No conflicts with existing `dkps`/`dkl` aliases

## Linear

Closes CAL-119