### PR TITLE
S3: terminal — tmux plugins, ghostty, starship colors, tmux-sessionizer

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -1,5 +1,24 @@
 theme = catppuccin-mocha
 
+# Font
+font-family = JetBrainsMono Nerd Font
+font-size = 13
+
+# Window
+window-padding-x = 8
+window-padding-y = 8
+
+# Scrollback
+scrollback-limit = 10000
+
+# Cursor
+cursor-style = bar
+cursor-style-blink = true
+
+# Shell integration (OSC sequences: nvim cursor shape, window titles, sudo prompts)
+shell-integration = zsh
+shell-integration-features = cursor,sudo,title
+
 # Splits: split right (main | new), split down (top | bottom). Navigate with super+arrows.
 keybind = super+d = new_split:right
 keybind = super+shift+d = new_split:down

--- a/scripts/tmux-sessionizer
+++ b/scripts/tmux-sessionizer
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------------------------
+# tmux-sessionizer — Fuzzy-jump to (or create) a tmux session per project dir
+# ------------------------------------------------------------------------------
+# What it does:
+#   Uses fzf to pick a directory from common project roots. If a tmux session
+#   already exists for that directory, switch to it. If not, create a new one
+#   named after the directory's basename.
+#
+# Usage:
+#   tmux-sessionizer              — fzf picker of project directories
+#   tmux-sessionizer <path>       — jump directly without picker
+#
+# Wired to: tmux prefix+f (.tmux.conf) and shell alias `ts` (aliases.shrc).
+# setup.sh symlinks this to ~/.local/bin/tmux-sessionizer (on PATH).
+#
+# Customize PROJECT_DIRS below to match your project roots.
+# ------------------------------------------------------------------------------
+
+PROJECT_DIRS=(
+  "$HOME"
+  "$HOME/projects"
+  "$HOME/work"
+  "$HOME/dev"
+  "$HOME/sys-config"
+)
+
+# If a path is passed directly, skip fzf
+if [[ $# -eq 1 ]]; then
+  selected="$1"
+else
+  # Build directory list: each base dir + its immediate subdirectories
+  dir_list=""
+  for base in "${PROJECT_DIRS[@]}"; do
+    [[ -d "$base" ]] || continue
+    dir_list+="$base"$'\n'
+    while IFS= read -r d; do
+      dir_list+="$d"$'\n'
+    done < <(find "$base" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+  done
+
+  selected=$(echo "$dir_list" | sort -u | fzf \
+    --prompt="  session: " \
+    --height=50% \
+    --reverse \
+    --border=rounded \
+    --preview='ls --color=always {} 2>/dev/null || echo "(empty)"')
+fi
+
+[[ -z "$selected" ]] && exit 0
+
+# Derive session name: basename, replace dots with underscores (tmux dislikes dots)
+session_name=$(basename "$selected" | tr '.' '_')
+
+if [[ -z "$TMUX" ]]; then
+  # Outside tmux: create or attach
+  tmux new-session -As "$session_name" -c "$selected"
+else
+  # Inside tmux: switch to existing session or create new detached one
+  if ! tmux has-session -t "=$session_name" 2>/dev/null; then
+    tmux new-session -ds "$session_name" -c "$selected"
+  fi
+  tmux switch-client -t "=$session_name"
+fi

--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -132,11 +132,11 @@ truncation_symbol = "…/"
 
 [git_branch]
 symbol = ""
-style = "bg:teal"
+style = "bg:green"
 format = '[[ $symbol $branch ](fg:base bg:green)]($style)'
 
 [git_status]
-style = "bg:teal"
+style = "bg:green"
 format = '[[($all_status)](fg:base bg:green)]($style)'
 conflicted = " "  # Git conflict icon
 ahead = " "        # Rocket icon
@@ -190,12 +190,13 @@ format = '[[ $symbol( $context) ](fg:#83a598 bg:color_bg3)]($style)'
 [gcloud]
 symbol = "󰅟"
 format = '[[ $symbol( $project) ](fg:black bg:yellow)]($style)'
-style = "bright-yellow"
+style = "bg:yellow"
 disabled = false
 
 [kubernetes]
 symbol = "󱃾"
 format = '[[ $symbol( $context) ](fg:black bg:blue)]($style)'
+style = "bg:blue"
 disabled = false
 
 # ------------------------------------------------------------------------------
@@ -205,7 +206,7 @@ disabled = false
 [time]
 disabled = false
 time_format = "%R"
-style = "bg:peach"
+style = "bg:purple"
 format = '[[  $time ](fg:mantle bg:purple)]($style)'
 
 # ------------------------------------------------------------------------------

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -58,6 +58,10 @@ bind - split-window -v
 unbind r
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
 
+# tmux-sessionizer: fuzzy jump to project dir / create session (prefix + f)
+# Script is on PATH via ~/.local/bin/tmux-sessionizer (symlinked by setup.sh)
+bind f run-shell "tmux-sessionizer"
+
 # ------------------------------------------------------------------------------
 # Copy-mode (scrollback and copy to clipboard)
 # ------------------------------------------------------------------------------
@@ -79,6 +83,12 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @yank_selection 'clipboard'
 set -g @clipboard 'external'
+
+# tmux-sensible: sane defaults everyone agrees on (escape time, scrollback, etc.)
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+# tmux-battery: battery status for status bar (used in @catppuccin_status_battery)
+set -g @plugin 'tmux-plugins/tmux-battery'
 
 # Catppuccin theme for status line and window list
 set -g @plugin 'catppuccin/tmux#v2.1.3'


### PR DESCRIPTION
## Stack position
**Merge order:** S1 → S2 → S3 → S4
This is **#3 of 4** — merge after S2, then retarget S4.

## What's in this PR
- **tmux/.tmux.conf**: add `tmux-sensible` and `tmux-battery` plugins; add `bind f run-shell "tmux-sessionizer"` (prefix+f to fuzzy jump to project)
- **ghostty/config**: add font-family, font-size, window padding, scrollback limit, cursor style, shell-integration
- **starship/starship.toml**: fix 5 module `style` fields to match powerline arrow colors (`git_branch`→bg:green, `git_status`→bg:green, `gcloud`→bg:yellow, `kubernetes`→bg:blue, `time`→bg:purple)
- **scripts/tmux-sessionizer**: new executable — fzf-powered project→tmux session switcher; wired to `prefix+f` and `ts` alias

## Tickets closed
CAL-90, CAL-91, CAL-92, CAL-116

## How to review
- `tmux.conf`: check plugin list and the `bind f` line
- `starship.toml`: each module's `style` field should match the `bg:` color in the surrounding format string
- `tmux-sessionizer`: read the script top to bottom; `PROJECT_DIRS` is the only thing you'd customize