### PR TITLE
docs: comprehensive setup, workflow, and keybinding docs

### DIFF
--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -1,647 +1,407 @@
-# Cheatsheet — Keymaps & Functions
+# Cheatsheet — Keymaps & Commands
 
-Quick reference for **Terminal (Zsh)**, **Tmux**, and **Neovim**: keybindings, commands, and how to interact with each part of the config.
+Quick reference for every tool in this config. Press `<Space>` in Neovim and pause — which-key shows all available keymaps for that prefix.
 
-| Context | Leader / prefix | Where bindings live |
-|---------|-----------------|----------------------|
-| **Neovim** | `<Space>` (leader) | `nvim/lua/cthayer/core/keymaps.lua` and each plugin in `nvim/lua/cthayer/plugins/*.lua` |
-| **Tmux** | `Ctrl-A` (prefix) | `tmux/.tmux.conf` and TPM plugins |
-
-**Other docs:** [INDEX.md](INDEX.md) (all docs) · [INSTALL.md](INSTALL.md) (install) · [DEBUG.md](DEBUG.md) (troubleshooting)
+| Context | Leader / prefix | Source |
+|---------|-----------------|--------|
+| **Neovim** | `<Space>` | `nvim/lua/cthayer/plugins/*.lua` |
+| **Tmux** | `Ctrl-A` | `tmux/.tmux.conf` |
 
 ---
 
 ## Terminal (Zsh)
 
-Your shell uses **vi-mode** (Oh My Zsh), **zsh-autosuggestions**, **zsh-autocomplete**, and **FZF**. New panes in tmux start with zsh.
+### Navigation
+| Key / Alias | Action |
+|-------------|--------|
+| `z <partial>` | Jump to frecent directory (zoxide) |
+| `zi` | Interactive directory picker (zoxide + fzf) |
+| `Tab` | fzf-powered completion popup |
+| `Ctrl-R` | Atuin history search (fuzzy, synced) |
+| `...` | `cd ../..` |
+| `cdh` / `cdm` / `cdc` | Home / `~/ct` / sys-config |
+| `pie` | `~/phillies/pie` |
 
-### Vi-mode (Command-line editing)
+### Shell aliases (quick reference)
+| Alias | Expands to |
+|-------|-----------|
+| `vim` / `vv` | `nvim` |
+| `c` | `clear` |
+| `xx` | `exit` |
+| `rsh` | `exec $SHELL` (reload shell) |
+| `sz` | `source ~/.zshrc` |
+| `ls` / `ll` | `eza -l --icons` / `eza -l -a --icons` |
+| `cat` | `bat` (syntax-highlighted cat) |
+| `lg` | `lazygit` |
+| `g` / `ga` / `gc` / `gp` | `git` / `add` / `commit -m` / `push` |
+| `gst` / `gd` / `gco` | `status` / `diff` / `checkout` |
+| `gsync` | `checkout main && pull --rebase && fetch --prune` |
+| `gcpr` | `gh pr create -w` |
+| `da` / `dr` | `direnv allow` / `direnv reload` |
+| `dev` | Start dev tmux session (nvim + terminal + Claude) |
 
-| Key | Mode | Action |
-|-----|------|--------|
-| `Esc` or `Ctrl-[` | → Normal | Enter normal (command) mode |
-| `i` or `a` | Normal → | Enter insert mode |
-| `h` / `j` / `k` / `l` | Normal | Move cursor left/down/up/right |
-| `w` / `b` | Normal | Next/previous word |
-| `0` / `$` | Normal | Start/end of line |
-| `^` | Normal | First non-blank of line |
-| `gg` / `G` | Normal | Start/end of history |
-| `x` | Normal | Delete char under cursor |
-| `dd` | Normal | Delete entire line |
-| `y` / `p` | Normal | Yank (copy) / put (paste) |
-| `u` | Normal | Undo |
-| `/` | Normal | Search history backward |
-| `n` / `N` | Normal | Next/prev search result |
+### Shell functions
+| Function | Description |
+|----------|-------------|
+| `glogone [n]` | Last N commits one-line (default 10) |
+| `delete_branches` | Interactively delete local branches |
+| `gcpp` | Switch gcloud config via fzf |
+| `query-gcp "SQL"` | Run BigQuery query with dry-run cost prompt |
 
-### Zsh-autosuggestions
-
+### Vi-mode (command-line editing)
 | Key | Action |
 |-----|--------|
-| `→` (Right) or `End` | Accept suggestion (when cursor at end) |
-
-### FZF (Fuzzy find — runs in tmux split when in tmux)
-
-| Key | Action |
-|-----|--------|
-| `Ctrl-R` | Search command history, insert result |
-| `Ctrl-E` | FZF file picker |
-| `Alt-c` | FZF cd (change directory) |
-| `Ctrl-O` | FZF launcher (files, dirs, history) |
-
-### Insert-mode (when typing)
-
-| Key | Action |
-|-----|--------|
-| `Ctrl-A` | Jump to line start |
-| `Ctrl-E` | Jump to line end |
-| `Ctrl-U` | Kill to line start |
-| `Ctrl-K` | Kill to line end |
-| `Ctrl-W` | Kill word before cursor |
-
-### Completion & tools
-
-- **Tab:** zsh-autocomplete — tab-complete commands, args, paths
-- **kubectl, gcloud, pyenv:** Shell completions enabled
-- **direnv:** Auto-loads `.envrc` in directories (use `da` to allow)
-- **pyenv / fnm / nvm:** Python and Node version switching
-
-### Ghostty + Dev session (opt-in)
-
-Run **`dev`** when you want this layout (not the default):
-
-- **Main (top):** Neovim  
-- **Bottom-left:** terminal (shell)  
-- **Bottom-right:** Claude Code — set `CODE_RIGHT_CMD` (e.g. `cursor .` or `open -a Cursor`); if unset, shell.
-
-```
-[     Neovim (main)     ]
-[ Terminal ] [ Claude Code ]
-```
-
-**How to adjust:**
-
-| What | How |
-|------|-----|
-| Bottom row height | `export CODE_BOTTOM_PCT=25` (default 25) before running `dev` |
-| Claude pane width | `export CODE_RIGHT_PCT=30` (default 30) |
-| Claude Code command | `export CODE_RIGHT_CMD='cursor .'` or `open -a Cursor` (empty = shell) |
-| Session name | `export CODE_SESSION_NAME=code` (default `code`) |
-| Repo path | If sys-config isn’t in `~/sys-config` or `~/ct/sys-config`, set `SYS_CONFIG_REPO` |
-
-Script: `scripts/code-session.sh`. If the session already exists, `dev` just attaches.
-
-**Ghostty native splits** (optional): `Super-D` split right, `Super-Shift-D` split down; `Super-←/→/↑/↓` move focus; `Super-=` equalize. Config: `ghostty/config`.
+| `Esc` | Enter normal mode |
+| `i` / `a` | Back to insert mode |
+| `w` / `b` | Word forward/back |
+| `0` / `$` | Line start/end |
+| `dd` | Delete line |
+| `/` | Search history |
+| `Ctrl-A` / `Ctrl-E` | Line start/end (insert mode) |
+| `Ctrl-W` | Delete word before cursor |
+| `→` / `End` | Accept autosuggestion |
 
 ---
 
 ## Tmux
 
-**Prefix:** `Ctrl-A` (replaces default `Ctrl-B`)
+**Prefix:** `Ctrl-A`
 
-### Sessions
-
+### Sessions & windows
 | Key | Action |
 |-----|--------|
-| `prefix + d` | Detach from session |
-| `prefix + s` | List sessions (switch) |
+| `prefix + d` | Detach |
+| `prefix + s` | List/switch sessions |
 | `prefix + $` | Rename session |
-| `prefix + F` | tmux-fzf: session, window, pane, command, keybinding, clipboard, process |
-
-### Windows
-
-| Key | Action |
-|-----|--------|
-| `prefix + c` | Create new window |
-| `prefix + n` | Next window |
-| `prefix + p` | Previous window |
-| `prefix + 0-9` | Go to window 0–9 |
-| `prefix + ,` | Rename current window |
-| `prefix + &` | Kill current window |
-| `prefix + w` | List windows (interactive) |
+| `prefix + c` | New window |
+| `prefix + n` / `p` | Next/prev window |
+| `prefix + 0–9` | Go to window N |
+| `prefix + ,` | Rename window |
+| `prefix + w` | Window list (interactive) |
+| `prefix + F` | tmux-fzf (sessions, windows, panes, commands) |
 
 ### Panes
-
 | Key | Action |
 |-----|--------|
-| `prefix + \|` | Split vertical |
-| `prefix + -` | Split horizontal |
+| `prefix + \|` | Split right |
+| `prefix + -` | Split down |
 | `prefix + h/j/k/l` | Move focus (vim-style) |
-| `prefix + o` | Next pane |
-| `prefix + ;` | Toggle last pane |
+| `Ctrl-h/j/k/l` | Move across tmux panes **and** Neovim splits (no prefix) |
+| `prefix + z` | Zoom pane (toggle fullscreen) |
 | `prefix + x` | Kill pane |
-| `prefix + z` | Zoom pane (toggle) |
-| Mouse | Click to focus; drag to resize |
+| Mouse | Click to focus; drag border to resize |
 
-### Copy mode (scrollback & copy)
-
+### Copy mode
 | Key | Action |
 |-----|--------|
 | `prefix + v` | Enter copy mode |
-| `v` | Start selection |
-| `y` | Yank selection to clipboard (tmux-yank) |
-| `Y` | Put (paste) from buffer |
-| `Esc` or `q` | Exit copy mode |
-| In copy mode: `h/j/k/l`, `/`, `n`, `N` | Vim-style navigation/search |
+| `v` | Start visual selection |
+| `y` | Yank to clipboard |
+| `h/j/k/l`, `/`, `n/N` | Vim-style navigation |
+| `q` / `Esc` | Exit copy mode |
 
-### tmux-yank (clipboard)
+### tmux-sessionizer
+| Key / Command | Action |
+|---------------|--------|
+| `prefix + f` | Open project picker (fzf over `~/ct`, `~/phillies`, `~`) |
+| `tmux-sessionizer <path>` | Create/attach session for that directory |
 
-| Key | Action |
-|-----|--------|
-| `prefix + Y` | Yank current pane's working directory |
-| Copy-mode `y` | Selection → system clipboard |
-
-### TPM (plugin manager)
-
+### TPM & config
 | Key | Action |
 |-----|--------|
 | `prefix + I` | Install plugins |
 | `prefix + U` | Update plugins |
-| `prefix + Alt-u` | Clean/uninstall plugins |
-
-### Config & state
-
-| Key | Action |
-|-----|--------|
-| `prefix + r` | Reload tmux config |
-| `prefix + Ctrl-s` | Save session (tmux-resurrect) |
-| `prefix + Ctrl-r` | Restore session (tmux-resurrect) |
-
-### Misc
-
-- **Mouse:** Enabled — click panes, scroll in copy mode
-- **tmux-continuum:** Auto-save every 15 min; auto-restore on tmux start
-- **vim-tmux-navigator:** `Ctrl-h/j/k/l` work across tmux panes and Neovim splits (no prefix)
+| `prefix + r` | Reload config |
+| `prefix + Ctrl-s` / `Ctrl-r` | Save / restore session (resurrect) |
 
 ---
 
 ## Neovim
 
-### Core motions & editing (normal mode)
+**Leader:** `<Space>`  
+**Tip:** Press `<Space>?` for buffer-local keymaps; press any group prefix and wait for which-key popup.
 
+### Core editing
 | Key | Action |
 |-----|--------|
-| `h` / `j` / `k` / `l` | Move left/down/up/right |
-| `w` / `b` / `e` | Next/prev word, end of word |
-| `0` / `^` / `$` | Line start, first char, line end |
-| `gg` / `G` | File start/end |
-| `Ctrl-u` / `Ctrl-d` | Half screen up/down |
-| `Ctrl-b` / `Ctrl-f` | Page up/down |
-| `%` | Match bracket |
-| `*` / `#` | Next/prev word under cursor |
-| `/` / `?` | Search forward/backward; `n` / `N` next/prev |
-| `d` / `y` / `c` + motion | Delete, yank, change |
-| `dd` / `yy` / `cc` | Line delete, yank, change |
-| `u` / `Ctrl-r` | Undo / redo |
-| `v` / `V` / `Ctrl-v` | Visual char/line/block |
-| `o` (visual) | Toggle selection end |
-
-### General
-
-| Key | Action |
-|-----|--------|
-| `jk` | Exit insert mode (alternative to Escape) |
+| `jk` | Exit insert mode |
 | `<Space>nh` | Clear search highlights |
-| `<Space>+` | Increment number under cursor |
-| `<Space>-` | Decrement number under cursor |
+| `<Space>+` / `<Space>-` | Increment / decrement number |
+| `u` / `Ctrl-r` | Undo / redo |
+| `<Space>uu` | Toggle undotree (visual undo history) |
 
-### Pane / Split Navigation (also works across Tmux)
-
+### Splits & tabs
 | Key | Action |
 |-----|--------|
-| `Ctrl-h` | Move focus left |
-| `Ctrl-j` | Move focus down |
-| `Ctrl-k` | Move focus up |
-| `Ctrl-l` | Move focus right |
-
-### Window & Split Management
-
-| Key | Action |
-|-----|--------|
-| `<Space>sv` | Split window vertically |
-| `<Space>sh` | Split window horizontally |
-| `<Space>se` | Equalize split dimensions |
-| `<Space>sx` | Close current split |
-| `<Space>sm` | Maximize/minimize current split |
-
-### Tabs
-
-| Key | Action |
-|-----|--------|
-| `<Space>to` | Open new tab |
-| `<Space>tx` | Close current tab |
-| `<Space>tn` | Go to next tab |
-| `<Space>tp` | Go to previous tab |
+| `<Space>sv` / `sh` | Split vertical / horizontal |
+| `<Space>se` / `sx` | Equalize / close split |
+| `<Space>sm` | Maximize/restore split |
+| `Ctrl-h/j/k/l` | Navigate splits (works across tmux too) |
+| `<Tab>` / `<S-Tab>` | Next / previous tab (bufferline) |
+| `<Space>to` / `tx` | New tab / close tab |
+| `<Space>tn` / `tp` | Next / prev tab |
 | `<Space>tf` | Open current buffer in new tab |
 
-### Telescope (Find & Search)
-
+### File navigation
 | Key | Action |
 |-----|--------|
-| `<Space>ff` | Fuzzy find files |
+| `<Space>ff` | Find files (Telescope) |
 | `<Space>fr` | Recent files |
-| `<Space>fs` | Live grep (find string in cwd) |
+| `<Space>fs` | Live grep |
 | `<Space>fc` | Find word under cursor |
 | `<Space>ft` | Find TODO/FIXME comments |
-| `<Space>fe` | File browser |
-| `<Space>fp` | Switch projects |
+| `<Space>fb` | List open buffers |
+| `<Space>fg` | Git files |
+| `<Space>ee` | File explorer (Neo-tree, float) |
+| `<Space>eg` | Git status tree |
+| `<Space>o` | Edit directory as buffer (Oil — rename/create/delete) |
 
-### Harpoon (Pin Files)
-
+### Harpoon (pin files)
 | Key | Action |
 |-----|--------|
 | `<Space>a` | Add file to harpoon |
-| `<Space>1` | Jump to file 1 |
-| `<Space>2` | Jump to file 2 |
-| `<Space>3` | Jump to file 3 |
-| `<Space>4` | Jump to file 4 |
-| `<Space>hm` | Harpoon menu |
+| `<Space>hm` | Open harpoon menu |
+| `<Space>1–4` | Jump to pinned file 1–4 |
 
-### Neo-tree (File Explorer)
-
+### Jump navigation
 | Key | Action |
 |-----|--------|
-| `<Space>ee` | Filesystem (float) |
-| `<Space>bf` | Buffers (float) |
-| `<Space>eg` | Git status (float) |
-
-### Oil (Edit Directory as Buffer)
-
-| Key | Action |
-|-----|--------|
-| `<Space>o` | Edit current directory as buffer (rename, create, delete files) |
-
-### Flash (Jump to Label)
-
-| Key | Action |
-|-----|--------|
-| `<Space>j` | Jump to any visible position via labels (n/x/o modes) |
-
-### Git — Fugitive & Gitsigns
-
-| Key | Action |
-|-----|--------|
-| `<Space>gs` | Git status |
-| `<Space>gd` | Git diff (vertical) |
-| `<Space>gD` | Git diff (horizontal) |
-| `<Space>gb` | Git blame |
-| `<Space>gh` | Git commit log (file) |
-| `<Space>lg` | Open LazyGit (repo) |
-| `<Space>lG` | Open LazyGit (current file) |
-| `<Space>lC` | Edit LazyGit config |
-| `]h` / `[h` | Next/previous hunk |
-| `<Space>hs` | Stage hunk |
-| `<Space>hr` | Reset hunk |
-| `<Space>hS` | Stage buffer |
-| `<Space>hR` | Reset buffer |
-| `<Space>hu` | Undo stage hunk |
-| `<Space>hp` | Preview hunk |
-| `<Space>hb` | Blame line (full) |
-| `<Space>hB` | Toggle line blame |
-| `<Space>hd` | Diff this |
-| `<Space>hD` | Diff with ~ |
-| `ih` (text object) | Select hunk |
+| `<Space>j` | Flash: jump to visible position via labels |
+| `s` + motion | Substitute with motion (replaces `s`) |
+| `ss` | Substitute entire line |
+| `S` | Substitute to end of line |
 
 ### LSP
-
 | Key | Action |
 |-----|--------|
+| `gd` | Go to definition |
 | `gD` | Go to declaration |
-| `gd` | LSP definitions |
-| `gi` | LSP implementations |
-| `gt` | LSP type definitions |
-| `gR` | LSP references |
-| `K` | Hover |
-| `<Space>ca` | Code actions |
-| `<Space>rn` | Rename (inline preview) |
-| `<Space>d` | Line diagnostics |
-| `<Space>D` | Buffer diagnostics |
-| `[d` / `]d` | Prev/next diagnostic |
+| `gi` | Go to implementation |
+| `gt` | Go to type definition |
+| `gR` | Show references |
+| `K` | Hover docs |
+| `<Space>ca` | Code action |
+| `<Space>rn` | Rename symbol (inline preview) |
 | `<Space>rs` | Restart LSP |
 | `<Space>uh` | Toggle inlay hints |
-| `:Mason` | Open Mason (LSP/formatter installer) |
+| `[d` / `]d` | Previous / next diagnostic |
+| `<Space>d` | Line diagnostics popup |
+| `<Space>ra` | Aerial: toggle symbol outline |
+| `<Space>rA` | Aerial: fuzzy symbol search (Telescope) |
+| `:Mason` | Open tool installer |
 
-### Trouble (Diagnostics & Lists)
-
+### Diagnostics & Trouble
 | Key | Action |
 |-----|--------|
-| `<Space>xx` | Toggle diagnostics |
-| `<Space>xw` | Open workspace diagnostics |
-| `<Space>xd` | Open document diagnostics |
+| `<Space>xx` | Toggle Trouble (diagnostics panel) |
+| `<Space>xw` | Workspace diagnostics |
+| `<Space>xd` | Document diagnostics |
 | `<Space>xq` | Quickfix list |
 | `<Space>xl` | Location list |
-| `<Space>xt` | Todo comments in Trouble |
-| `<Space>xr` | LSP references |
+| `<Space>xt` | TODO comments |
 
-### Formatting
-
+### Git — Fugitive
 | Key | Action |
 |-----|--------|
-| `<Space>mp` | Format buffer or selection (conform, manual) |
+| `<Space>gs` | Git status (`:G`) |
+| `<Space>gv` | Diff working tree vs index (vertical split) |
+| `<Space>gD` | Diff working tree vs index (horizontal split) |
+| `<Space>gb` | Git blame |
+| `<Space>gL` | File commit log (`:0Gclog`) |
+| `<Space>gr` | Interactive rebase (type branch + Enter) |
+
+### Git — Diffview
+| Key | Action |
+|-----|--------|
+| `<Space>gd` | Open diff vs HEAD (full UI) |
+| `<Space>gh` | File history for current buffer |
+| `<Space>gH` | Repo-wide file history |
+| `<Space>gc` | Close diffview |
+
+### Git — Gitsigns (hunk operations)
+| Key | Action |
+|-----|--------|
+| `]h` / `[h` | Next / prev hunk |
+| `<Space>hs` | Stage hunk |
+| `<Space>hr` | Reset hunk |
+| `<Space>hS` | Stage entire buffer |
+| `<Space>hR` | Reset entire buffer |
+| `<Space>hu` | Undo stage hunk |
+| `<Space>hp` | Preview hunk inline |
+| `<Space>hb` | Blame line (full commit info) |
+| `<Space>hB` | Toggle inline blame |
+| `<Space>hd` | Diff this hunk |
+| `ih` | Text object: select hunk (use with `d`, `y`, `c`) |
+
+### Git — LazyGit
+| Key | Action |
+|-----|--------|
+| `<Space>lg` | Open LazyGit (full repo) |
+| `<Space>lG` | Open LazyGit (current file) |
+| `<Space>lC` | Edit LazyGit config |
+
+### Git — Octo (GitHub PRs & issues in Neovim)
+| Key | Action |
+|-----|--------|
+| `<Space>go` | List PRs |
+| `<Space>gi` | List issues |
+| `<Space>gR` | Start review |
+| **Inside PR buffers:** | |
+| `<Space>po` | Checkout PR |
+| `<Space>pm` / `pM` | Merge / squash-merge |
+| `<Space>pd` | Show diff |
+| `<Space>pf` | List changed files |
+| `<Space>pc` | List commits |
+| `<Space>pv` / `pV` | Add / remove reviewer |
+| `<Space>px` / `pO` | Close / reopen PR |
+| `<Space>pu` / `pb` | Copy URL / open in browser |
+| **Inside issue buffers:** | |
+| `<Space>ix` / `io` | Close / reopen issue |
+| `<Space>il` | List repo issues |
+| `<Space>ia` | Add assignee |
+| `<Space>iL` | Add label |
+| `<Space>iu` / `ib` | Copy URL / open in browser |
+| **Review threads:** | |
+| `<Space>ca` | Add comment |
+| `<Space>vs` | Submit review |
+| `<Space>va` / `vr` | Approve / request changes |
+
+### Yanky (yank ring)
+| Key | Action |
+|-----|--------|
+| `p` / `P` | Paste after / before (enhanced, adds to ring) |
+| `<C-n>` / `<C-p>` | After pasting: cycle forward / back through yank ring |
+| `y` | Yank (adds to ring) |
+| `<Space>fy` | Telescope yank history picker |
+
+### Session management (Persistence)
+| Key | Action |
+|-----|--------|
+| `<Space>qs` | Restore session for current directory |
+| `<Space>ql` | Restore last session (any directory) |
+| `<Space>qd` | Delete / stop saving session |
+| `<Space>qq` | Quit without saving session |
+
+### Find & replace (Spectre)
+| Key | Action |
+|-----|--------|
+| `<Space>S` | Open Spectre (project-wide find/replace) |
+| `<Space>sw` | Search word under cursor across project |
+| `<Space>sw` (visual) | Search selected text |
+| `<Space>sf` | Search in current file only |
+
+### Debugging (nvim-dap)
+| Key | Action |
+|-----|--------|
+| `<Space>db` | Toggle breakpoint |
+| `<Space>dB` | Conditional breakpoint (prompts for expression) |
+| `<Space>dc` | Continue / start debug session |
+| `<Space>dn` | Step over |
+| `<Space>di` | Step into |
+| `<Space>do` | Step out |
+| `<Space>dr` | Open REPL |
+| `<Space>dl` | Run last debug config |
+| `<Space>du` | Toggle DAP UI panels |
+| `<Space>de` | Evaluate expression (normal or visual) |
+| `<Space>dx` | Terminate session |
+
+### Testing (Neotest)
+| Key | Action |
+|-----|--------|
+| `<Space>Tr` | Run nearest test |
+| `<Space>TT` | Run all tests in file |
+| `<Space>Ts` | Toggle test summary panel |
+| `<Space>To` | Show output for nearest test |
+| `<Space>TO` | Toggle output panel |
+| `<Space>Td` | Debug nearest test (uses DAP) |
+| `<Space>Tx` | Stop running tests |
+
+### Formatting
+| Key | Action |
+|-----|--------|
+| `<Space>mp` | Format buffer / selection (conform, manual) |
 | `<Space>gf` | Format file (LSP / null-ls) |
+| *(auto)* | Format on save (conform) |
 
-### Refactoring (visual mode for extract)
-
+### Refactoring
 | Key | Action |
 |-----|--------|
 | `<Space>re` | Extract function (visual) |
 | `<Space>rv` | Extract variable (visual) |
-| `<Space>ri` | Inline variable (normal) |
+| `<Space>ri` | Inline variable |
 | `<Space>rM` | Refactoring menu |
 
-### Substitute (replace with motion)
-
-| Key | Action |
-|-----|--------|
-| `s` + motion | Substitute with motion |
-| `ss` | Substitute entire line |
-| `S` | Substitute to end of line |
-| `s` (visual) | Substitute selection |
-
-### Comment
-
+### Comments
 | Key | Action |
 |-----|--------|
 | `gcc` | Toggle line comment |
 | `gbc` | Toggle block comment |
-| `gc` + motion | Comment lines |
-| `gb` + motion | Comment block |
-| `gco` | Add comment above |
-| `gcO` | Add comment below |
-| `gcA` | Add comment at end of line |
+| `gc` + motion | Comment range |
+| `gco` / `gcO` | Add comment above / below |
+| `gcA` | Append comment at end of line |
 
-### Surround (nvim-surround)
-
+### Surround
 | Key | Action |
 |-----|--------|
-| `ys` + motion + char | Add surround |
-| `cs` + old + new | Change surround |
+| `ys` + motion + char | Add surround (e.g. `ysiw"` → `"word"`) |
+| `cs` + old + new | Change surround (e.g. `cs"'`) |
 | `ds` + char | Delete surround |
-| e.g. `ysiw"` | Wrap word in double quotes |
-| e.g. `cs"'` | Change `"` to `'` |
 
-### Treesitter (incremental selection & text objects)
-
+### Treesitter text objects
 | Key | Action |
 |-----|--------|
-| `Ctrl-Space` | Init/expand selection (node) |
+| `Ctrl-Space` | Expand selection to node |
 | `Backspace` | Shrink selection |
-| `af` / `if` | Around/inner function |
-| `ac` / `ic` | Around/inner class |
-| `ab` / `ib` | Around/inner block |
-| `]f` / `[f` | Next/prev function start |
-| `]F` / `[F` | Next/prev function end |
-| `]c` / `[c` | Next/prev class start |
-| `]C` / `[C` | Next/prev class end |
+| `af` / `if` | Around / inner function |
+| `ac` / `ic` | Around / inner class |
+| `ab` / `ib` | Around / inner block |
+| `]f` / `[f` | Next / prev function |
+| `]c` / `[c` | Next / prev class |
 
-### Todo Comments
-
-| Key | Action |
-|-----|--------|
-| `]t` / `[t` | Next/previous TODO/FIXME |
-
-### Undo Tree
-
-| Key | Action |
-|-----|--------|
-| `<Space>uu` | Toggle undotree |
-
-### Terminal
-
-| Key | Action |
-|-----|--------|
-| `<Space>tt` | Toggle floating terminal |
-
-### Alpha (Startup Dashboard)
-
-| Key | Action |
-|-----|--------|
-| `e` | New file |
-| `f` | Find file |
-| `r` | Recent files |
-| `c` | Open config |
-| `q` | Quit |
-
-### Claude Code (claudecode.nvim)
-
-Requires [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude doctor`).
-
-| Key | Action |
-|-----|--------|
-| `<Space>c` | Claude Code (group) |
-| `<Space>cc` | Toggle Claude |
-| `<Space>cf` | Focus Claude |
-| `Alt-w` | **Switch editor ↔ Claude** (works from editor or from Claude input) |
-| `<Space>cw` | Same as Alt+w (leader form) |
-| `<Space>cr` | Resume Claude |
-| `<Space>cC` | Continue Claude |
-| `<Space>cm` | Select Claude model |
-| `<Space>cb` | Add current buffer to Claude |
-| `<Space>cs` | Send selection (visual); in neo-tree/oil: add file |
-| `<Space>cA` | Accept diff |
-| `<Space>cd` | Deny diff |
-
-### Misc
-
-| Key | Action |
-|-----|--------|
-| `<Space>z` | Toggle NoNeckPain (center buffer) |
-| `<Space>?` | Show buffer-local keymaps (which-key) |
-
-### Completion (Insert Mode)
-
+### Completion (insert mode)
 | Key | Action |
 |-----|--------|
 | `Ctrl-Space` | Trigger completion |
-| `Ctrl-k` / `Ctrl-j` | Prev/next item |
+| `Ctrl-k` / `Ctrl-j` | Prev / next item |
 | `Ctrl-b` / `Ctrl-f` | Scroll docs |
-| `Ctrl-e` | Abort completion |
-| `Enter` | Confirm selection |
+| `Ctrl-e` | Abort |
+| `Enter` | Confirm |
 
----
+### Claude Code
+| Key | Action |
+|-----|--------|
+| `<Space>cc` | Toggle Claude panel |
+| `<Space>cf` | Focus Claude |
+| `Alt-w` | Switch editor ↔ Claude (works from either side) |
+| `<Space>cr` | Resume last Claude session |
+| `<Space>cC` | Continue Claude |
+| `<Space>cm` | Select model |
+| `<Space>cb` | Add current buffer to Claude |
+| `<Space>cs` (visual) | Send selection to Claude |
+| `<Space>cs` (neo-tree/oil) | Add file to Claude |
+| `<Space>cA` / `cd` | Accept / deny diff |
 
-## Shell aliases & commands
+### Misc
+| Key | Action |
+|-----|--------|
+| `<Space>?` | Show buffer-local keymaps (which-key) |
+| `<Space>z` | Toggle NoNeckPain (center buffer) |
+| `<Space>tt` | Toggle floating terminal |
+| `]t` / `[t` | Next / prev TODO comment |
+| `<Space>uu` | Toggle undotree |
 
-Commands you type (from `aliases.shrc` and `functions.shrc`).
-
-### Navigation
-
-| Alias | Command |
-|-------|---------|
-| `...` | `cd ../..` |
-| `cdh` | `cd $HOME` |
-| `cdm` | `cd $HOME/ct` |
-| `cdc` | `cd $HOME/ct/sys-config` |
-| `pie` | `cd $HOME/phillies/pie` |
-| `terraform` | `cd $HOME/phillies/terraform` |
-
-### Editor
-
-| Alias | Command |
-|-------|---------|
-| `vim` / `vv` | `nvim` |
-
-### Shell
-
-| Alias | Command |
-|-------|---------|
-| `c` | `clear` |
-| `xx` | `exit` |
-| `rsh` | `exec $SHELL` |
-| `sz` | `source ~/.zshrc` |
-
-### File Listing
-
-| Alias | Command |
-|-------|---------|
-| `ls` | `eza -l --icons` |
-| `ll` | `eza -l -a --icons` |
-| `cat` | `bat` |
-
-### Git
-
-| Alias | Command |
-|-------|---------|
-| `g` | `git` |
-| `ga` | `git add` |
-| `gc` / `gm` | `git commit -m` |
-| `gp` | `git push` |
-| `gl` | `git log --oneline` |
-| `gst` | `git status` |
-| `gd` | `git diff` |
-| `gdc` | `git diff --cached` |
-| `gma` | `git commit -am` |
-| `gb` | `git branch` |
-| `gco` | `git checkout` |
-| `gpu` | `git pull` |
-| `gf` | `git fetch` |
-| `gcl` | `git clone` |
-| `gra` | `git remote add` |
-| `grr` | `git remote rm` |
-| `gcpr` | `gh pr create -w` |
-| `gsync` | `git checkout main && git pull --rebase && git fetch --prune` |
-| `glom` | `git pull origin main` |
-| `lg` | `lazygit` |
-
-### Docker
-
-| Alias | Command |
-|-------|---------|
-| `dkps` | `docker ps` |
-| `dkpsa` | `docker ps -a` |
-| `dkimgs` | `docker images` |
-| `dkst` | `docker stats` |
-| `dkl` | `docker logs -f` |
-| `dke` | `docker exec -it` |
-| `dkclean` | `docker rm $(docker ps -aq)` |
-| `dk-up` | `docker-compose up -d` |
-| `dk-down` | `docker-compose down` |
-| `dk-start` / `dk-stop` | Start/stop compose |
-| `dk-clean` | `docker system prune -a --volumes` |
-
-### Kubernetes
-
-| Alias/Function | Command |
-|----------------|---------|
-| `kgp` | `kubectl get pods` |
-| `kgj` | `kubectl get jobs` |
-| `kjr` | `kubectl get jobs \| grep Running` |
-| `kjf` | `kubectl get jobs \| grep Failed` |
-| `ka <file>` | `kubectl apply -f <file>` |
-| `kdj <job>` | `kubectl delete job <job>` |
-
-### Python
-
-| Alias | Command |
-|-------|---------|
-| `python` / `pip` | `python3` / `pip3` |
-| `uvp` | `uv pip install -r pyproject.toml` |
-| `uvr` | `uv pip uninstall -y -r <(uv pip freeze)` |
-
-### Direnv
-
-| Alias | Command |
-|-------|---------|
-| `da` | `direnv allow` |
-| `dr` | `direnv reload` |
-
-### R
-
-| Alias | Command |
-|-------|---------|
-| `R` | `R --no-restore-data --no-save` |
-| `r` | `radian` |
-
-### Terraform
-
-| Alias | Command |
-|-------|---------|
-| `tf` | `./terraform.sh` |
-
-### DuckDB
-
-| Alias | Command |
-|-------|---------|
-| `duckdb` | Launch DuckDB CLI |
-
-### System / Network
-
-| Alias | Command |
-|-------|---------|
-| `ports` | `lsof -i -P -n \| grep LISTEN` |
-| `ip` | `curl ifconfig.me` |
-| `devip` | `ipconfig getifaddr en0` |
-
----
-
-## Shell Functions
-
-### GCP
-
-| Function | Description |
-|----------|-------------|
-| `gcpp` | Interactively switch gcloud config via fzf |
-
-### Git
-
-| Function | Description |
-|----------|-------------|
-| `glogone [n]` | Show last N commits (default 10) in oneline format |
-| `delete_branches` | Interactively delete local branches (prompts each) |
-
-### BigQuery / GCP Data
-
-| Function | Description |
-|----------|-------------|
-| `query-gcp "SQL"` | Run BigQuery query with dry-run cost confirmation |
-| `bigquery` | Open BigQuery console for current GCP project |
-
-### Cloud SQL Proxy (Phillies)
-
-| Function | Description |
-|----------|-------------|
-| `phil-db-up <name>` | Start proxy and connect to MySQL (e.g. `prod`, `biomech`) |
-| `phil-db-up --all` | Start proxies for prod + biomech |
-| `phil-db-switch` | Switch MySQL connection to another instance socket |
-| `phil-db-status` | Show proxy PIDs and active sockets |
-| `phil-db-down` | Stop proxies and clean socket files |
-
-### Logging (from functions.shrc)
-
-| Function | Description |
-|----------|-------------|
-| `log_info "msg"` | Blue INFO log |
-| `log_warn "msg"` | Yellow WARN log |
-| `log_error "msg"` | Red ERROR log |
-| `log_ok "msg"` | Green OK log |
-| `log_prompt "msg"` | Yellow PROMPT log |
-
----
-
-## Tips
-
-- **Neovim:** Press `<Space>` and wait — which-key shows available keymaps for that prefix.
-- **Buffer-local keymaps:** `<Space>?` shows keymaps for the current buffer (e.g. LSP, gitsigns).
-- **Forgot a keymap?** Check which-key groups: `<Space>f` (file), `<Space>g` (git), `<Space>h` (gitsigns), etc.
-- **Tmux + Neovim:** `Ctrl-h/j/k/l` work across both — no prefix needed in Neovim splits.
-- **Tmux:** `prefix + ?` lists every keybinding.
-- **Terminal:** In vi-mode, press `Esc` to edit the line with vim keys; `i` or `a` to type again.
+### Alpha dashboard (startup)
+| Key | Action |
+|-----|--------|
+| `n` | New file |
+| `e` | File explorer |
+| `f` / `F` | Find file / Git files |
+| `w` | Find word (live grep) |
+| `r` | Recent files |
+| `b` | Git branches |
+| `g` | LazyGit |
+| `t` | Find TODOs |
+| `p` | Plugins (Lazy) |
+| `c` | Config (`$MYVIMRC`) |
+| `l` | Lazy changelog |
+| `q` | Quit |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,8 +9,10 @@ This folder is the single place for all **human-readable documentation** for sys
 | Document | Use when you want to… |
 |----------|------------------------|
 | **[INSTALL.md](INSTALL.md)** | Install the config on a new machine, understand what gets symlinked, verify the setup, or run clean-room tests. |
+| **[WORKFLOWS.md](WORKFLOWS.md)** | Task-based guide: how to navigate code, run git workflows, debug, test, manage sessions, and use Claude Code with this config. |
+| **[CHEATSHEET.md](CHEATSHEET.md)** | Quick reference for every keybinding and command: Zsh, Tmux, and all Neovim leader keymaps (LSP, git, DAP, Telescope, etc.). |
+| **[UPDATING.md](UPDATING.md)** | How to update plugins, add new tools, make config changes, and maintain the repo over time. |
 | **[DEBUG.md](DEBUG.md)** | Something broke after install or after pulling changes: shell, tmux, Neovim, git, or setup script. Step-by-step fixes and a validation checklist. |
-| **[CHEATSHEET.md](CHEATSHEET.md)** | Look up keybindings and commands: Zsh (vi-mode, FZF), Tmux (prefix keybindings, copy mode, plugins), Neovim (leader keymaps, LSP, Telescope, Git, etc.). |
 | **[GIT-REBASE.md](GIT-REBASE.md)** | Run an interactive rebase: with Fugitive (`<Space>gr`), LazyGit, or the terminal. Explains pick/reword/squash and continue/abort. |
 | **[AUDIT-AND-PLAN.md](AUDIT-AND-PLAN.md)** | Historical audit snapshot (deprecated). Inventory and recommendations are out of date; see repo and [CHEATSHEET.md](CHEATSHEET.md) for current plugins/keymaps. |
 | **[TESTING.md](TESTING.md)** | How to run lint (config parse/load) and validate (post-install); optional CI. |
@@ -22,6 +24,8 @@ This folder is the single place for all **human-readable documentation** for sys
 - **Neovim leader:** `<Space>` — see [CHEATSHEET.md](CHEATSHEET.md) for all `<Space>…` bindings.
 - **Tmux prefix:** `Ctrl-A` — see [CHEATSHEET.md](CHEATSHEET.md) for all `prefix + …` bindings.
 - **Install from scratch:** [INSTALL.md](INSTALL.md) → clone repo → `bash setup.sh` → `exec $SHELL` → tmux: `prefix + I`.
+- **How to do X:** [WORKFLOWS.md](WORKFLOWS.md) — task-based guide for common workflows.
+- **Adding/updating tools:** [UPDATING.md](UPDATING.md) — which file to edit, how to add plugins, update Homebrew.
 - **Something’s wrong:** [DEBUG.md](DEBUG.md) and/or `bash scripts/validate.sh`.
 - **Config checks:** `bash scripts/lint.sh` (before commit); `bash scripts/validate.sh` (after install). See [TESTING.md](TESTING.md).
 

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,0 +1,234 @@
+# Updating & Maintaining This Config
+
+How to keep the config current, add new tools, make changes, and manage the repo.
+
+---
+
+## Updating tools
+
+### Neovim plugins
+```bash
+# Inside Neovim
+:Lazy update          # update all plugins
+:Lazy sync            # install missing + update + clean unused
+:Lazy clean           # remove unused plugins
+```
+
+After updating, check for errors on next Neovim startup. If something breaks:
+- `:Lazy restore` to roll back to the last known-good `lazy-lock.json`
+- Or revert `nvim/lazy-lock.json` in git: `git checkout HEAD -- nvim/lazy-lock.json`
+
+### LSP servers, formatters, linters
+```bash
+# Inside Neovim
+:Mason                # opens the installer UI
+:MasonUpdate          # update all installed tools
+```
+
+To add a new tool: open `:Mason`, search, press `i` to install. It installs to `~/.local/share/nvim/mason/`. Mason-installed binaries are automatically available to LSP and none-ls.
+
+### Homebrew (shell tools, apps)
+```bash
+brew update && brew upgrade          # update everything
+brew bundle --file=Brewfile          # install anything missing from Brewfile
+brew bundle cleanup --file=Brewfile  # remove things not in Brewfile (dry-run first)
+```
+
+### Tmux plugins (TPM)
+Inside tmux: `prefix + U` to update all plugins.
+
+### Node (fnm)
+```bash
+fnm install 22        # install Node 22 (required for Copilot)
+fnm default 22        # set as default for new shells
+```
+
+---
+
+## Making config changes
+
+### Which file to edit
+| What you want to change | File |
+|-------------------------|------|
+| Neovim plugin config | `nvim/lua/cthayer/plugins/<plugin>.lua` |
+| Neovim options (line numbers, tabs, etc.) | `nvim/lua/cthayer/core/options.lua` |
+| Neovim core keymaps (non-plugin) | `nvim/lua/cthayer/core/keymaps.lua` |
+| Shell aliases | `zsh/aliases.shrc` |
+| Shell functions | `zsh/functions.shrc` |
+| Shell config, plugins, PATH | `zsh/.zshrc` |
+| Login env, PATH, tool init | `zsh/.zprofile` |
+| Tmux config | `tmux/.tmux.conf` |
+| Installed tools (brew, casks) | `Brewfile` |
+| Git config (user, aliases, delta) | `git-configs/.gitconfig` |
+| Global gitignore | `git-configs/.gitignore_global` |
+| Ghostty terminal config | `ghostty/config` |
+| Starship prompt | `starship/starship.toml` |
+| Bootstrap script | `setup.sh` |
+
+All config files are symlinked from your home directory into this repo by `setup.sh`, so editing the file in the repo takes effect immediately (no copy step needed).
+
+### Adding a new Neovim plugin
+
+1. Create `nvim/lua/cthayer/plugins/<name>.lua` following the existing pattern:
+```lua
+-- Header comment explaining what it does and keymaps
+return {
+    "author/plugin-name",
+    event = "VeryLazy",  -- or keys = {...} for lazy-loading
+    opts = {},           -- or config = function() ... end for setup
+}
+```
+
+2. If it adds keymaps under a new leader prefix, add a group label to `which-key.lua`:
+```lua
+{ "<leader>x", name = "+my-group" },
+```
+
+3. Lazy.nvim auto-discovers any file in `nvim/lua/cthayer/plugins/` — no import needed.
+
+4. Restart Neovim; `:Lazy` will show the new plugin and install it.
+
+### Removing a Neovim plugin
+
+1. Delete `nvim/lua/cthayer/plugins/<name>.lua`
+2. Run `:Lazy clean` in Neovim to remove the installed files
+3. Remove any group label from `which-key.lua` if relevant
+4. Remove from `nvim/lazy-lock.json` entry (Lazy handles this automatically)
+
+### Adding a new shell alias or function
+- Short aliases go in `zsh/aliases.shrc`
+- Multi-line functions go in `zsh/functions.shrc`
+- Run `sz` (or `source ~/.zshrc`) to reload without opening a new terminal
+
+### Adding a Homebrew package
+Edit `Brewfile`:
+```ruby
+brew "tool-name"           # CLI tool
+cask "App Name"            # macOS app
+```
+Then run `brew bundle --file=Brewfile` to install.
+
+---
+
+## Verifying changes
+
+### Before committing
+```bash
+bash scripts/lint.sh    # zsh syntax, bash syntax, tmux parse, nvim headless load
+```
+
+Fix any failures before pushing — CI runs the same checks on every PR.
+
+### After pulling changes
+```bash
+bash scripts/validate.sh   # verifies symlinks, tools on PATH, key configs reachable
+```
+
+---
+
+## Repo structure
+
+```
+sys-config/
+├── Brewfile                    # Homebrew packages and casks
+├── setup.sh                    # Bootstrap script (run once on fresh machine)
+├── .gitignore / .luarc.json    # Repo-level config
+├── docs/                       # This documentation
+├── ghostty/config              # Ghostty terminal settings
+├── git-configs/
+│   ├── .gitconfig              # Git user, aliases, delta, LFS
+│   └── .gitignore_global       # Global ignores (OS, Python, editors)
+├── nvim/
+│   ├── init.lua                # Entry point
+│   ├── lazy-lock.json          # Plugin lockfile (commit after :Lazy update)
+│   └── lua/cthayer/
+│       ├── core/
+│       │   ├── options.lua     # Vim options
+│       │   └── keymaps.lua     # Core keymaps (non-plugin)
+│       ├── lazy.lua            # lazy.nvim bootstrap
+│       └── plugins/            # One file per plugin
+├── scripts/
+│   ├── lint.sh                 # Config syntax/load checks (CI + local)
+│   ├── validate.sh             # Post-install symlink/tool verification
+│   └── tmux-sessionizer        # Project session picker
+├── starship/starship.toml      # Prompt
+├── tmux/.tmux.conf             # Tmux config + TPM plugins
+└── zsh/
+    ├── .zshrc                  # Interactive shell config
+    ├── .zprofile               # Login shell config
+    ├── aliases.shrc            # All shell aliases
+    └── functions.shrc          # Shell functions
+```
+
+---
+
+## Git workflow for this repo
+
+### Making a change
+```bash
+# Edit whatever you need
+bash scripts/lint.sh    # verify it passes
+git add <files>
+git commit -m "type(scope): what and why"
+git push
+```
+
+### Commit message conventions
+```
+feat(nvim): add telescope-file-browser plugin
+fix(zsh): correct fzf-tab initialization order
+chore(brew): update Brewfile with new tools
+docs: update CHEATSHEET with new keymaps
+```
+
+### Pulling changes on an existing machine
+```bash
+cd ~/sys-config           # or wherever the repo lives
+git pull
+bash scripts/validate.sh  # verify everything is still wired up
+# In Neovim: :Lazy sync   # install/update plugins to match lazy-lock.json
+```
+
+---
+
+## Setting up a fresh machine
+
+> Full step-by-step: [INSTALL.md](INSTALL.md)
+
+```bash
+# 1. Clone
+git clone git@github.com:caseyluna/sys-config.git ~/sys-config
+cd ~/sys-config
+
+# 2. Bootstrap
+bash setup.sh
+
+# 3. Reload shell
+exec $SHELL
+
+# 4. Tmux plugins — attach tmux then:
+# prefix + I
+
+# 5. Node (for Copilot)
+fnm install 22 && fnm default 22
+
+# 6. Neovim — first launch auto-installs plugins via lazy.nvim
+nvim
+# then: :MasonUpdate to get all LSP servers/formatters
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Plugin error on startup | `:Lazy restore` to roll back, or check the plugin's GitHub for breaking changes |
+| LSP not attaching | `:LspInfo` to see status; `:Mason` to verify the server is installed; `<Space>rs` to restart |
+| Formatter not running | `:ConformInfo` to see what's configured for the filetype |
+| Shell alias not found | `sz` to reload; check for typos in `aliases.shrc` |
+| Tmux pane navigation broken | `prefix + r` to reload config; check vim-tmux-navigator is installed in both tmux and Neovim |
+| Copilot Node.js warning | `fnm install 22 && fnm default 22`, then open a new terminal |
+| Symlink broken after moving repo | Re-run `bash setup.sh` — it re-creates all symlinks pointing to the new path |
+
+Full troubleshooting: [DEBUG.md](DEBUG.md)

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,220 @@
+# Workflows
+
+Task-based guide for common developer workflows using the full stack of tools in this config. Each section shows the fastest path through a task using the right tool for the job.
+
+---
+
+## Starting a session
+
+### Fresh machine, new project
+1. `tmux-sessionizer` — pick project directory → creates a named session
+2. Neovim opens automatically with `<Space>qs` to restore last session if one exists
+3. `<Space>ff` to find files, or `e` on the dashboard to open the file tree
+
+### Returning to work
+1. `ta` (alias: `tmux attach`) or `prefix + s` to pick a session
+2. Persistence auto-restores your layout: buffers, splits, cursor positions per cwd
+3. If Claude was open: `<Space>cr` to resume the last session
+
+---
+
+## Code navigation
+
+### Finding anything fast
+| Situation | Tool | Key |
+|-----------|------|-----|
+| Know the filename | Telescope find files | `<Space>ff` |
+| Know a string in the code | Telescope live grep | `<Space>fs` |
+| Want the word under cursor | Telescope word search | `<Space>fc` |
+| Know the function/class name | Aerial symbol search | `<Space>rA` |
+| Recent files | Telescope oldfiles | `<Space>fr` |
+| Jump to a visible position | Flash labels | `<Space>j` |
+| Pin 4 key files for a task | Harpoon | `<Space>a` to add, `<Space>1–4` to jump |
+
+### Navigating a codebase you don't know
+1. `<Space>fs` live grep to find entry points
+2. `gd` on a function call to follow definitions (LSP)
+3. `gR` to see all references to a symbol
+4. `<Space>ra` to open the aerial outline sidebar — scan the file's structure
+5. `gt` to jump to the type definition
+6. `K` on anything to read hover docs without leaving the file
+
+---
+
+## Git workflow
+
+### Day-to-day git (LazyGit — recommended)
+`<Space>lg` opens LazyGit. From there:
+- `Space` to stage/unstage files
+- `c` to commit
+- `P` to push
+- `p` to pull
+- `b` to manage branches
+- `r` on a branch to rebase interactively
+- `q` to close
+
+### Reviewing your own changes before committing
+1. `<Space>gd` — diffview opens a full split diff vs HEAD; navigate files in the left panel
+2. `<Space>hs` to stage individual hunks directly in Neovim, or stage whole file with `<Space>hS`
+3. `<Space>gv` — fugitive vertical split shows working tree vs index for the current file
+
+### Reviewing someone else's PR
+1. `<Space>go` — Octo opens a PR list; pick one
+2. `<Space>pf` to see changed files, `<Space>pd` to see the diff
+3. `<Space>gR` to start a formal review
+4. In review threads: `<Space>ca` to add a comment, `<Space>va` to approve, `<Space>vr` to request changes, `<Space>vs` to submit
+
+### Exploring history
+| What | Key |
+|------|-----|
+| Full repo history with diffs | `<Space>gH` (diffview repo history) |
+| One file's history | `<Space>gh` (diffview file history) |
+| One file's commits (quickfix) | `<Space>gL` (fugitive 0Gclog) |
+| Blame current line | `<Space>hb` |
+| Toggle blame column | `<Space>hB` |
+
+### Fixing a merge conflict
+1. `<Space>gd` to open diffview — it detects conflicts automatically
+2. Diffview shows the 3-way merge layout: ours | result | theirs
+3. Edit the result buffer to resolve
+4. `<Space>gc` to close diffview when done
+5. Stage the resolved file: `<Space>hS`
+
+### Interactive rebase
+- From Neovim: `<Space>gr` → type base branch → Enter; edit the todo buffer
+- From LazyGit: `<Space>lg` → commits list → `e` for interactive rebase
+- Full guide: [GIT-REBASE.md](GIT-REBASE.md)
+
+---
+
+## Editing workflows
+
+### Project-wide find & replace
+1. `<Space>S` opens Spectre
+2. Type search pattern, tab to replacement
+3. `<Space>sw` with cursor on a word to pre-fill the search
+4. Apply per-match, per-file, or all at once inside the Spectre buffer
+
+### Refactoring code
+1. Visual select the code you want to extract
+2. `<Space>re` to extract as a function, `<Space>rv` to extract as a variable
+3. `<Space>ri` on a variable to inline it
+4. `<Space>rn` to rename a symbol across the whole project (LSP)
+5. `gR` to verify all references updated correctly
+
+### Working with multiple files
+1. `<Space>a` to add up to 4 core files to Harpoon; `<Space>1–4` to jump instantly
+2. Use tabs (`<Tab>`/`<S-Tab>`) for different contexts (e.g. implementation + test)
+3. `<Space>sf` to search/replace only within the current file
+
+### Yank ring (don't lose what you copied)
+1. Yank multiple things with `y` — all go into the ring
+2. Paste with `p`, then `<C-n>`/`<C-p>` to cycle through previous yanks
+3. `<Space>fy` to open Telescope yank history and pick any past yank
+
+### Undo history
+- `<Space>uu` opens undotree — a visual tree of every edit state
+- Navigate with `j/k`, press Enter to jump to that state
+- Undo branches are preserved even after redoing, unlike linear undo
+
+---
+
+## Debugging
+
+### Python
+1. Install debugpy via Mason: `:MasonInstall debugpy`
+2. Open a Python file, `<Space>db` to set a breakpoint on the line you want to pause at
+3. `<Space>dc` to start — pick "Launch file" or "Launch file with args"
+4. DAP UI opens automatically: scopes on the left, REPL at the bottom
+5. `<Space>dn` step over, `<Space>di` step into, `<Space>do` step out
+6. `<Space>de` on any variable to evaluate its current value
+7. `<Space>dx` to terminate; `<Space>du` to close the UI panels
+
+> If the session ends with an error, the UI stays open so you can inspect state. `<Space>du` to close manually.
+
+### JavaScript / TypeScript
+1. Install js-debug-adapter via Mason: `:MasonInstall js-debug-adapter`
+2. Same flow as Python — `<Space>db`, `<Space>dc`, pick "Launch file" or "Attach to process"
+
+### Debugging a specific test
+1. Put the cursor on the test function
+2. `<Space>Td` — Neotest runs the test with DAP attached
+3. Breakpoints you set with `<Space>db` will be hit
+
+---
+
+## Testing
+
+### Running tests
+| What | Key |
+|------|-----|
+| Run test under cursor | `<Space>Tr` |
+| Run entire file | `<Space>TT` |
+| See all results | `<Space>Ts` (summary panel) |
+| Read output / error for a test | `<Space>To` |
+| Stop running | `<Space>Tx` |
+
+### Test workflow
+1. Write your test, put cursor inside the function
+2. `<Space>Tr` to run it immediately
+3. Green ✓ or red ✗ appears in the gutter inline
+4. On failure: `<Space>To` to read the full output/traceback
+5. `<Space>Ts` to see all tests in the summary panel and jump to failures
+
+**Supported frameworks:** pytest, go test, Jest, Vitest
+
+---
+
+## Session management
+
+### Automatic session save
+Persistence saves your session (buffers, layout, cursor) when you quit, keyed by cwd. Next time you `nvim` in the same directory it's all there.
+
+| Key | Action |
+|-----|--------|
+| `<Space>qs` | Restore session for current directory |
+| `<Space>ql` | Restore last session (any directory) |
+| `<Space>qq` | Quit this time without saving |
+
+### tmux-sessionizer
+`prefix + f` opens an fzf picker over your project directories. Selecting one:
+- Creates a new tmux session named after the directory if it doesn't exist
+- Attaches if it does
+
+Run directly: `tmux-sessionizer ~/phillies/pie`
+
+---
+
+## Working with Claude Code
+
+### Basic usage
+- `<Space>cc` to toggle the panel; `Alt-w` to switch focus between editor and Claude
+- `<Space>cb` to add the current buffer as context
+- Visual select + `<Space>cs` to send a specific selection
+
+### Inline diff workflow
+1. Ask Claude to make a change
+2. Claude writes the diff directly into the buffer
+3. Review it, then `<Space>cA` to accept or `<Space>cd` to deny
+
+### Tips
+- Use `<Space>cr` to resume a previous conversation with full context
+- Open multiple files in splits and use `<Space>cb` on each to give Claude more context
+- `<Space>cm` to switch models mid-conversation
+
+---
+
+## Config & tools maintenance
+
+> See [UPDATING.md](UPDATING.md) for the full guide on updating plugins, adding new ones, and managing this config.
+
+### Quick tasks
+| Task | How |
+|------|-----|
+| Install a new LSP server or formatter | `:Mason` → search → `i` to install |
+| Update all Neovim plugins | `:Lazy update` |
+| Update all shell/system tools | `brew update && brew upgrade` |
+| Check what's broken | `bash scripts/lint.sh` |
+| Verify symlinks after pulling | `bash scripts/validate.sh` |
+| Reload tmux config without restart | `prefix + r` |
+| Reload shell config | `sz` (alias for `source ~/.zshrc`) |


### PR DESCRIPTION
## Summary

- **CHEATSHEET.md** — Full overhaul. Added every keybinding from S5–S7 that was missing: diffview, Octo (PR/issue/review), yanky ring, persistence sessions, aerial, spectre, nvim-dap, neotest, and bufferline `<Tab>`/`<S-Tab>`. Fixed stale entries (`<Space>gd` now correctly attributed to diffview; fugitive diff corrected to `<Space>gv`). Restructured layout for faster scanning.
- **WORKFLOWS.md** (new) — Task-based guide organized around what you're trying to do: start a session, navigate a codebase, run a git workflow (LazyGit day-to-day, PR review with Octo, conflict resolution, rebase), edit (Spectre find/replace, LSP refactoring, yank ring, undotree), debug with DAP, run tests with Neotest, manage sessions with Persistence + tmux-sessionizer, and use Claude Code.
- **UPDATING.md** (new) — Maintenance reference. How to update Neovim plugins (`:Lazy`), LSP/formatters (`:Mason`), Homebrew, tmux plugins, and Node/fnm. Which file to edit for every type of config change. How to add or remove a plugin with the pattern. Repo structure map. Git commit conventions for this repo. Fresh machine setup steps. Troubleshooting table.
- **INDEX.md** — Updated to include WORKFLOWS.md and UPDATING.md with accurate descriptions and quick-reference links.

## Test plan

- [ ] Read each doc in the browser and verify links resolve correctly
- [ ] Cross-check a sample of keybindings against the actual plugin configs
- [ ] Merge after PR #51 (stack/7 → dev-audit) is merged so the cheatsheet reflects the final plugin state

🤖 Generated with [Claude Code](https://claude.com/claude-code)