### PR TITLE
fix(tmux+shell): keybind improvements and dynamic gcpp

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -11,11 +11,12 @@
 #   Reload config: prefix + r. Install/update plugins: prefix + I (capital I).
 #
 # Keybinding summary (prefix = Ctrl-A):
-#   Panes: prefix+|/- (split v/h), prefix+h/j/k/l (move), prefix+v (copy mode), v/y (select, yank).
-#   Windows: prefix+c/n/p/0-9 (new, next, prev, goto). Sessions: prefix+d (detach), prefix+s (list).
+#   Panes: prefix+|/- (split v/h), prefix+h/j/k/l (move), prefix+H/J/K/L (resize), prefix+v (copy mode).
+#   Copy mode: v (select), y (yank), Escape (cancel). Windows: prefix+c/n/p/</>  (new, next, prev, reorder).
+#   Sessions: prefix+d (detach), prefix+s (list).
 #   Config: prefix+r (reload). Plugins: prefix+I (install). Resurrect: prefix+Ctrl-s/r (save/restore).
 #
-# Author: Casey A. Thayer
+# Author: Casey Luna
 # Location: ~/.tmux.conf (symlinked from repo)
 # ------------------------------------------------------------------------------
 
@@ -42,7 +43,7 @@ set -g mouse on
 # Leader (prefix): Ctrl-A; repeat-time 0 so repeated prefix works
 unbind C-b
 set -g prefix C-a
-set -g repeat-time 0
+set -g repeat-time 500
 
 # Vim-style pane navigation: prefix + h/j/k/l to move between panes
 bind -r h select-pane -L
@@ -53,6 +54,16 @@ bind -r l select-pane -R
 # Splits: prefix + | (vertical), prefix + - (horizontal)
 bind | split-window -h
 bind - split-window -v
+
+# Pane resize: prefix + H/J/K/L (repeatable — hold prefix and tap to nudge)
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Window reorder: prefix + < / > (swap window left / right)
+bind -r < swap-window -t -1 \; previous-window
+bind -r > swap-window -t +1 \; next-window
 
 # Reload this config: prefix + r
 unbind r
@@ -70,6 +81,7 @@ bind f run-shell "tmux-sessionizer"
 bind 'v' copy-mode
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 bind-key -T copy-mode-vi 'y' send -X copy-selection
+bind-key -T copy-mode-vi 'Escape' send -X cancel
 
 # Keep copy-mode active after mouse-drag selection (don't exit on MouseDragEnd)
 unbind -T copy-mode-vi MouseDragEnd1Pane

--- a/zsh/functions.shrc
+++ b/zsh/functions.shrc
@@ -10,7 +10,7 @@
 #   Sourced from .zshrc at startup. Edit in repo (zsh/functions.shrc); reload
 #   with: source ~/.zshrc. Each function has a USAGE/DESCRIPTION block above it.
 #
-# Author: Casey Thayer
+# Author: Casey Luna
 # Location: ~/.functions.shrc (symlinked from repo)
 # ------------------------------------------------------------------------------
 
@@ -61,32 +61,23 @@ gcpp() {
     log_error "gcloud CLI not found."
     return 1
   }
-  command -v jq >/dev/null || {
-    log_error "jq not found."
-    return 1
-  }
   command -v fzf >/dev/null || {
     log_error "fzf not found."
     return 1
   }
 
-  # ☁️ List available gcloud configs and let the user pick one with fzf
-  log_info "Select from a list of GCP projects..."
-  local projects="
-    phil-new
-    phil-new-stg
-  "
-  local choice project_id
-  choice="$(echo "$projects" | fzf --prompt="Select project: " --with-nth=1,2)"
-  
+  # ☁️ Fetch live project list from gcloud and let the user pick with fzf
+  log_info "Fetching GCP projects..."
+  local project_id
+  project_id="$(gcloud projects list --format="value(projectId)" 2>/dev/null | fzf --prompt="Select project: ")"
+
   # ❌ Exit if nothing selected
-  if [[ -z "$choice" ]]; then
+  if [[ -z "$project_id" ]]; then
     log_warn "No project selected. Aborting."
     return
   fi
 
-  # ✅ Activate the selected config
-  project_id="$(awk '{print $1}' <<< "$choice")"
+  # ✅ Activate the selected project
   log_info "Setting GCP project: $project_id"
   gcloud config set project "$project_id"
   log_ok "Set GCP project to: '$project_id'"


### PR DESCRIPTION
## Summary

Closes CAL-136, CAL-137, CAL-127.

### tmux

- **`repeat-time 0 → 500ms`** — repeatable binds now work: hold prefix and tap `h/j/k/l` or resize keys without re-pressing prefix each time
- **Pane resize** (`prefix + H/J/K/L`) — nudge panes 5 cells per press, repeatable
- **Window reorder** (`prefix + <` / `>`) — swap window left/right, repeatable
- **Escape in copy-mode-vi** — cancels and exits; no more hunting for `q`

### shell

- **`gcpp`** — replaced hardcoded `phil-new`/`phil-new-stg` list with `gcloud projects list --format="value(projectId)"` piped to fzf; works on any machine, always reflects live projects; dropped `jq` dependency

## Test plan

- [ ] `prefix + r` to reload config (no tmux restart needed)
- [ ] `prefix + h h h` — focus moves left repeatedly without re-pressing prefix
- [ ] `prefix + H H H` — pane grows left by 15 cells
- [ ] `prefix + <` / `>` — window swaps position in window list
- [ ] `prefix + v` → `Escape` — exits copy mode
- [ ] `gcpp` — fzf picker shows live GCP projects from `gcloud`

🤖 Generated with [Claude Code](https://claude.com/claude-code)