### PR TITLE
feat(nvim): Neovim UX stack — file-browser removal, LSP status, harpoon v2, doc updates

### DIFF
--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -87,9 +87,16 @@ Quick reference for every tool in this config. Press `<Space>` in Neovim and pau
 | `prefix + -` | Split down |
 | `prefix + h/j/k/l` | Move focus (vim-style) |
 | `Ctrl-h/j/k/l` | Move across tmux panes **and** Neovim splits (no prefix) |
+| `prefix + H/J/K/L` | Resize pane (repeatable) |
 | `prefix + z` | Zoom pane (toggle fullscreen) |
 | `prefix + x` | Kill pane |
 | Mouse | Click to focus; drag border to resize |
+
+### Windows
+| Key | Action |
+|-----|--------|
+| `prefix + <` | Swap window left (repeatable) |
+| `prefix + >` | Swap window right (repeatable) |
 
 ### Copy mode
 | Key | Action |
@@ -150,6 +157,7 @@ Quick reference for every tool in this config. Press `<Space>` in Neovim and pau
 | `<Space>fs` | Live grep |
 | `<Space>fc` | Find word under cursor |
 | `<Space>ft` | Find TODO/FIXME comments |
+| `<Space>fp` | Switch project (Telescope projects) |
 | `<Space>fb` | List open buffers |
 | `<Space>fg` | Git files |
 | `<Space>ee` | File explorer (Neo-tree, float) |
@@ -185,7 +193,7 @@ Quick reference for every tool in this config. Press `<Space>` in Neovim and pau
 | `<Space>rs` | Restart LSP |
 | `<Space>uh` | Toggle inlay hints |
 | `[d` / `]d` | Previous / next diagnostic |
-| `<Space>d` | Line diagnostics popup |
+| `<Space>D` | Line diagnostics popup |
 | `<Space>ra` | Aerial: toggle symbol outline |
 | `<Space>rA` | Aerial: fuzzy symbol search (Telescope) |
 | `:Mason` | Open tool installer |
@@ -320,7 +328,7 @@ Quick reference for every tool in this config. Press `<Space>` in Neovim and pau
 | Key | Action |
 |-----|--------|
 | `<Space>mp` | Format buffer / selection (conform, manual) |
-| `<Space>gf` | Format file (LSP / null-ls) |
+| `<Space>gf` | Format file (conform) |
 | *(auto)* | Format on save (conform) |
 
 ### Refactoring

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -53,7 +53,7 @@ Task-first quick reference. Find what you want to do, get the exact keys. For fu
 
 | I want to… | Keys |
 |------------|------|
-| See diagnostics for the current line | `<Space>d` |
+| See diagnostics for the current line | `<Space>D` |
 | Jump to next / previous diagnostic | `]d` / `[d` |
 | Open the diagnostics panel | `<Space>xx` |
 | Run a code action (fix / import / etc.) | `<Space>ca` |
@@ -146,6 +146,8 @@ Task-first quick reference. Find what you want to do, get the exact keys. For fu
 | Split pane right | `Ctrl-A |` |
 | Split pane down | `Ctrl-A -` |
 | Zoom a pane to fullscreen | `Ctrl-A z` |
+| Resize pane (repeatable) | `Ctrl-A H/J/K/L` |
+| Swap window left / right | `Ctrl-A <` / `Ctrl-A >` |
 | Copy text in tmux | `Ctrl-A v` → `v` to select → `y` to yank |
 | Save session to disk | `Ctrl-A Ctrl-S` |
 | Restore session from disk | `Ctrl-A Ctrl-R` |

--- a/nvim/lua/cluna/plugins/harpoon.lua
+++ b/nvim/lua/cluna/plugins/harpoon.lua
@@ -1,23 +1,27 @@
 -- ------------------------------------------------------------------------------
--- harpoon (ThePrimeagen/harpoon) — Pin files and jump with one key
+-- harpoon (ThePrimeagen/harpoon) — Pin files and jump with one key (v2)
 -- ------------------------------------------------------------------------------
 -- What it does: Mark up to 4 (or more) files and jump to them with number keys.
---   No conflict: <leader>a (add), <leader>1/2/3/4 (go to); leader+5+ for more.
+--   No conflict: <leader>a (add), <leader>1/2/3/4 (go to); <leader>hm (menu).
 -- Keymaps: <leader>a (add file), <leader>1/2/3/4 (go to file 1–4), <leader>hm (menu).
--- Notes: Depends on plenary. which-key: we add "a" and "1"-"4" as harpoon group.
+-- Notes: Uses Harpoon v2 API (branch = "harpoon2"). Plenary no longer required.
 -- ------------------------------------------------------------------------------
 
 return {
 	"ThePrimeagen/harpoon",
+	branch = "harpoon2",
 	event = "BufReadPre",
 	dependencies = { "nvim-lua/plenary.nvim" },
-	keys = {
-		{ "<leader>a", function() require("harpoon.mark").add_file() end, desc = "Harpoon: add file" },
-		{ "<leader>1", function() require("harpoon.ui").nav_file(1) end, desc = "Harpoon: go to file 1" },
-		{ "<leader>2", function() require("harpoon.ui").nav_file(2) end, desc = "Harpoon: go to file 2" },
-		{ "<leader>3", function() require("harpoon.ui").nav_file(3) end, desc = "Harpoon: go to file 3" },
-		{ "<leader>4", function() require("harpoon.ui").nav_file(4) end, desc = "Harpoon: go to file 4" },
-		{ "<leader>hm", function() require("harpoon.ui").toggle_quick_menu() end, desc = "Harpoon: menu" },
-	},
-	opts = {},
+	config = function()
+		local harpoon = require("harpoon")
+		harpoon:setup()
+
+		vim.keymap.set("n", "<leader>a", function() harpoon:list():add() end, { desc = "Harpoon: add file" })
+		vim.keymap.set("n", "<leader>hm", function() harpoon.ui:toggle_quick_menu(harpoon:list()) end, { desc = "Harpoon: menu" })
+
+		vim.keymap.set("n", "<leader>1", function() harpoon:list():select(1) end, { desc = "Harpoon: go to file 1" })
+		vim.keymap.set("n", "<leader>2", function() harpoon:list():select(2) end, { desc = "Harpoon: go to file 2" })
+		vim.keymap.set("n", "<leader>3", function() harpoon:list():select(3) end, { desc = "Harpoon: go to file 3" })
+		vim.keymap.set("n", "<leader>4", function() harpoon:list():select(4) end, { desc = "Harpoon: go to file 4" })
+	end,
 }

--- a/nvim/lua/cluna/plugins/lualine.lua
+++ b/nvim/lua/cluna/plugins/lualine.lua
@@ -2,7 +2,7 @@
 -- lualine.nvim (nvim-lualine/lualine.nvim) — Statusline
 -- ------------------------------------------------------------------------------
 -- What it does: Statusline with mode, branch, diff, diagnostics, filename,
---   encoding, filetype, and optional Lazy plugin update indicator.
+--   encoding, filetype, active LSP servers, and optional Lazy plugin update indicator.
 -- Keymaps: None.
 -- Notes: Custom theme in config; depends on nvim-web-devicons.
 -- ------------------------------------------------------------------------------
@@ -26,6 +26,17 @@ return {
 	config = function()
 		local lualine = require("lualine")
 		local lazy_status = require("lazy.status")
+
+		-- Returns names of active LSP servers for the current buffer
+		local function lsp_status()
+			local clients = vim.lsp.get_clients({ bufnr = 0 })
+			if #clients == 0 then return "" end
+			local names = {}
+			for _, c in ipairs(clients) do
+				table.insert(names, c.name)
+			end
+			return "\u{f489} " .. table.concat(names, " ")
+		end
 
 		-- 🎨 Define a custom color palette for the theme
 		local colors = {
@@ -90,6 +101,7 @@ return {
 						cond = lazy_status.has_updates,
 						color = { fg = "#ff9e64" },
 					},
+					{ lsp_status, color = { fg = colors.green } },
 					"encoding",
 					"fileformat",
 					"filetype",

--- a/nvim/lua/cluna/plugins/telescope.lua
+++ b/nvim/lua/cluna/plugins/telescope.lua
@@ -1,10 +1,10 @@
 -- ------------------------------------------------------------------------------
 -- telescope.nvim (nvim-telescope/telescope.nvim) — Fuzzy finder + extensions
 -- ------------------------------------------------------------------------------
--- What it does: Find files, recent, grep, todos; file browser; project switch.
---   Extensions: ui-select (LSP menus), fzf-native (faster sort), file_browser, project.
--- Keymaps: <leader>ff/fr/fs/fc/ft, <leader>fe (file browser), <leader>fp (projects).
--- Notes: fzf-native improves fuzzy sort; file_browser and project need this config.
+-- What it does: Find files, recent, grep, todos; project switch.
+--   Extensions: ui-select (LSP menus), fzf-native (faster sort), project.
+-- Keymaps: <leader>ff/fr/fs/fc/ft, <leader>fp (projects).
+-- Notes: fzf-native improves fuzzy sort; project extension needs this config.
 -- ------------------------------------------------------------------------------
 
 return {
@@ -13,7 +13,6 @@ return {
 	-- Native fzf sorter for Telescope (must be built on install)
 	{ "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
 
-	{ "nvim-telescope/telescope-file-browser.nvim" },
 	{ "nvim-telescope/telescope-project.nvim" },
 
 	{
@@ -22,7 +21,6 @@ return {
 		dependencies = {
 			"nvim-lua/plenary.nvim",
 			"nvim-telescope/telescope-fzf-native.nvim",
-			"nvim-telescope/telescope-file-browser.nvim",
 			"nvim-telescope/telescope-project.nvim",
 		},
 		config = function()
@@ -33,14 +31,12 @@ return {
 					["ui-select"] = {
 						require("telescope.themes").get_dropdown({}),
 					},
-					file_browser = { hijack_netrw = true },
 					project = { base_dirs = { "~/.config", "~" }, hidden_files = true },
 				},
 			})
 
 			telescope.load_extension("ui-select")
 			telescope.load_extension("fzf")
-			telescope.load_extension("file_browser")
 			telescope.load_extension("project")
 
 			local keymap = vim.keymap
@@ -49,7 +45,6 @@ return {
 			keymap.set("n", "<leader>fs", "<cmd>Telescope live_grep<cr>", { desc = "Find string in cwd" })
 			keymap.set("n", "<leader>fc", "<cmd>Telescope grep_string<cr>", { desc = "Find word under cursor" })
 			keymap.set("n", "<leader>ft", "<cmd>TodoTelescope<cr>", { desc = "Find todos" })
-			keymap.set("n", "<leader>fe", "<cmd>Telescope file_browser<cr>", { desc = "Telescope file browser" })
 			keymap.set("n", "<leader>fp", "<cmd>Telescope project<cr>", { desc = "Telescope projects" })
 		end,
 	},


### PR DESCRIPTION
## Summary

- **CAL-133** Remove `telescope-file-browser` — drops plugin spec, dependency, extension config, `load_extension` call, and `<leader>fe` keymap from `telescope.lua`
- **CAL-134** Add LSP attach status to lualine — `lsp_status()` in `lualine_x` shows active server names with a nerd-font icon using `vim.lsp.get_clients({ bufnr = 0 })`
- **CAL-135** Migrate Harpoon v1 → v2 — switches to `branch = "harpoon2"`, rewrites all keymaps to new API (`harpoon:list():add()`, `harpoon:list():select(n)`, `harpoon.ui:toggle_quick_menu(harpoon:list())`)
- **Docs** — `CHEATSHEET.md` + `KEYS.md`: add tmux pane resize (`H/J/K/L`) and window swap (`<`/`>`), fix `<Space>d` → `<Space>D` for line diagnostics, fix `<Space>gf` description (conform, not null-ls)

## Test plan
- [ ] Open Neovim — confirm `<leader>fe` no longer exists; `<leader>fp` opens project picker
- [ ] Confirm lualine statusline shows LSP server name(s) after attaching
- [ ] Open a file, `<leader>a` adds to harpoon, `<leader>1`–`4` jumps correctly, `<leader>hm` opens menu
- [ ] Verify `<Space>gf` formats via conform (no null-ls errors)
- [ ] Verify `<Space>D` shows line diagnostics popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)